### PR TITLE
add tests, use AreTypesAssignable

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecretsInParamsMustBeSecureTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecretsInParamsMustBeSecureTests.cs
@@ -58,6 +58,21 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             CompileAndTest(bicep, 0);
         }
 
+        [DataRow(@"param password string", false)]
+        [DataRow(@"param password object", false)]
+        [DataRow(@"param password array", true)]
+        [DataRow(@"param password bool", true)]
+        [DataRow(@"param password int", true)]
+        [DataRow(@"@secure()
+                   param password string", true)]
+        [DataRow(@"@secure()
+                   param password object", true)]
+        [DataTestMethod]
+        public void ShouldOnlyFailForStringAndObject(string bicep, bool shouldPass)
+        {
+            CompileAndTest(bicep, shouldPass ? 0 : 1);
+        }
+
         // password
         [DataRow(@"param fail_adminPasswordInt int")]
         [DataRow(@"param fail_adminPassword string")]

--- a/src/Bicep.Core/Analyzers/Linter/Common/TypeExtensions.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Common/TypeExtensions.cs
@@ -10,10 +10,19 @@ namespace Bicep.Core.Analyzers.Linter.Common
         /// <summary>
         /// True if the given type symbol is a string type (and not "any")
         /// </summary>
-        public static bool IsStrictlyAssignableToString(this TypeSymbol typeSymbol)
+        public static bool IsString(this TypeSymbol typeSymbol)
         {
             return typeSymbol is not AnyType
                 && TypeValidator.AreTypesAssignable(typeSymbol, LanguageConstants.String);
+        }
+
+        /// <summary>
+        /// True if the given type symbol is an object type (and not "any")
+        /// </summary>
+        public static bool IsObject(this TypeSymbol typeSymbol)
+        {
+            return typeSymbol is not AnyType
+                && TypeValidator.AreTypesAssignable(typeSymbol, LanguageConstants.Object);
         }
     }
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecretsInParamsMustBeSecureRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecretsInParamsMustBeSecureRule.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Analyzers.Linter.Common;
 using Bicep.Core.CodeAction;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -19,8 +21,6 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public const int MaxNumber = 256;
 
         private static readonly Regex HasSecretRegex = new("password|pwd|secret|accountkey|acctkey", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        private static readonly Regex IsType = new("string|object", RegexOptions.Compiled);
 
         // Allow certain patterns we know about in ARM
         private static readonly Regex AllowedRegex = new(
@@ -64,8 +64,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         private IDiagnostic? AnalyzeUnsecuredParameter(ParameterSymbol parameterSymbol)
         {
             string name = parameterSymbol.Name;
-            string type = parameterSymbol.Type.ToString();
-            if (IsType.IsMatch(type))
+            TypeSymbol type = parameterSymbol.Type;
+            if (type.IsObject() || type.IsString())
             {
                 if (HasSecretRegex.IsMatch(name))
                 {

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
@@ -88,7 +88,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     // We only want to trigger if the expression is of type string (because interpolation
                     // using non-string types can be a perfectly valid way to convert to string, e.g. '${intVar}')
                     var type = model.GetTypeInfo(expression);
-                    if (type.IsStrictlyAssignableToString())
+                    if (type.IsString())
                     {
                         AddCodeFix(valueSyntax.Span, expression.ToText());
                     }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
@@ -217,7 +217,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             private static Failure? AnalyzeIdProperty(SemanticModel model, ObjectPropertySyntax propertySyntax)
             {
                 var type = model.GetTypeInfo(propertySyntax.Value);
-                if (type.IsStrictlyAssignableToString())
+                if (type.IsString())
                 {
                     return AnalyzeIdPropertyValue(model, propertySyntax, propertySyntax.Value, Array.Empty<DeclaredSymbol>());
                 }


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
