### PR TITLE
adding IObjectParser and derived classes

### DIFF
--- a/src/Bicep.Core.UnitTests/Semantics/YamlDeserializationTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/YamlDeserializationTests.cs
@@ -105,7 +105,7 @@ namespace Bicep.Core.UnitTests.Semantics
 
         private static void CompareSimpleJSON(string json)
         {
-            var jToken = SystemNamespaceType.ExtractTokenFromObject(json);
+            var jToken = YamlObjectParser.ExtractTokenFromObject(json);
             var correctList = new List<int> { 1, 2 };
             var correctObject = new Dictionary<string, int> { { "nestedInt", 1 }, };
 

--- a/src/Bicep.Core.UnitTests/Semantics/YamlDeserializationTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/YamlDeserializationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Semantics.YamlObjectParser;
 
 namespace Bicep.Core.UnitTests.Semantics
 {

--- a/src/Bicep.Core/Semantics/IObjectParser.cs
+++ b/src/Bicep.Core/Semantics/IObjectParser.cs
@@ -9,7 +9,8 @@ namespace Bicep.Core.Semantics
     public interface IObjectParser
     {
         public abstract JToken ExtractTokenFromObject(string fileContent);
-        public abstract ErrorType GetParsingError(IPositionable positionable);
-        public abstract JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath);
+        public abstract ErrorType GetExtractTokenError(IPositionable positionable);
+        public abstract ErrorType GetExtractTokenFromPathError(IPositionable positionable);
+        public abstract JToken? ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath);
     }
 }

--- a/src/Bicep.Core/Semantics/IObjectParser.cs
+++ b/src/Bicep.Core/Semantics/IObjectParser.cs
@@ -10,9 +10,9 @@ namespace Bicep.Core.Semantics
 {
     public interface IObjectParser
     {
+        abstract bool TryExtractFromObject(string fileContent, string? tokenSelectorPath, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken);
         abstract JToken ExtractTokenFromObject(string fileContent);
         abstract ErrorDiagnostic GetExtractTokenErrorType(IPositionable positionable);
-        abstract bool TryExtractFromTokenByPath(JToken token, string? tokenSelectorPath, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken);
-        abstract bool TryExtractFromObject(string fileContent, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken);
+        abstract bool TryExtractFromTokenByPath(JToken token, string tokenSelectorPath, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken);
     }
 }

--- a/src/Bicep.Core/Semantics/IObjectParser.cs
+++ b/src/Bicep.Core/Semantics/IObjectParser.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+
+namespace Bicep.Core.Semantics
+{
+    public interface IObjectParser
+    {
+        JToken ExtractTokenFromObject(string fileContent);
+        JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath);
+    }
+}

--- a/src/Bicep.Core/Semantics/IObjectParser.cs
+++ b/src/Bicep.Core/Semantics/IObjectParser.cs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Collections.Immutable;
-using Bicep.Core.Semantics.Namespaces;
-using Bicep.Core.Syntax;
-using Bicep.Core.TypeSystem;
+using Newtonsoft.Json.Linq;
 
 namespace Bicep.Core.Semantics
 {
     public interface IObjectParser
     {
-        JToken ExtractTokenFromObject(string fileContent);
-        JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath);
+        public abstract JToken ExtractTokenFromObject(string fileContent);
+        public abstract JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath);
     }
 }

--- a/src/Bicep.Core/Semantics/IObjectParser.cs
+++ b/src/Bicep.Core/Semantics/IObjectParser.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Diagnostics.CodeAnalysis;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Parsing;
 using Bicep.Core.TypeSystem;
 using Newtonsoft.Json.Linq;
@@ -8,9 +10,9 @@ namespace Bicep.Core.Semantics
 {
     public interface IObjectParser
     {
-        public abstract JToken ExtractTokenFromObject(string fileContent);
-        public abstract ErrorType GetExtractTokenError(IPositionable positionable);
-        public abstract ErrorType GetExtractTokenFromPathError(IPositionable positionable);
-        public abstract JToken? ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath);
+        abstract JToken ExtractTokenFromObject(string fileContent);
+        abstract ErrorDiagnostic GetExtractTokenErrorType(IPositionable positionable);
+        abstract bool TryExtractFromTokenByPath(JToken token, string? tokenSelectorPath, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken);
+        abstract bool TryExtractFromObject(string fileContent, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken);
     }
 }

--- a/src/Bicep.Core/Semantics/IObjectParser.cs
+++ b/src/Bicep.Core/Semantics/IObjectParser.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using Bicep.Core.Parsing;
+using Bicep.Core.TypeSystem;
 using Newtonsoft.Json.Linq;
 
 namespace Bicep.Core.Semantics
@@ -7,6 +9,7 @@ namespace Bicep.Core.Semantics
     public interface IObjectParser
     {
         public abstract JToken ExtractTokenFromObject(string fileContent);
+        public abstract ErrorType GetError(IPositionable positionable);
         public abstract JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath);
     }
 }

--- a/src/Bicep.Core/Semantics/IObjectParser.cs
+++ b/src/Bicep.Core/Semantics/IObjectParser.cs
@@ -9,7 +9,7 @@ namespace Bicep.Core.Semantics
     public interface IObjectParser
     {
         public abstract JToken ExtractTokenFromObject(string fileContent);
-        public abstract ErrorType GetError(IPositionable positionable);
+        public abstract ErrorType GetParsingError(IPositionable positionable);
         public abstract JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath);
     }
 }

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -9,7 +9,7 @@ namespace Bicep.Core.Semantics
     public class JsonObjectParser : ObjectParser
     {
         override public JToken ExtractTokenFromObject(string fileContent) => fileContent.TryFromJson<JToken>();
-        override public ErrorType GetError(IPositionable positionable)
+        override public ErrorType GetParsingError(IPositionable positionable)
         {
             return ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).UnparseableJsonType());
         }

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -12,5 +12,5 @@ namespace Bicep.Core.Semantics
             => fileContent.TryFromJson<JToken>();
         override public ErrorDiagnostic GetExtractTokenErrorType(IPositionable positionable)
             => DiagnosticBuilder.ForPosition(positionable).UnparseableJsonType();
-
+    }
 }

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -10,7 +10,7 @@ namespace Bicep.Core.Semantics
     {
         override public JToken ExtractTokenFromObject(string fileContent)
             => fileContent.TryFromJson<JToken>();
-        override public ErrorType GetExtractTokenError(IPositionable positionable)
-            => ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).UnparseableJsonType());
-    }
+        override public ErrorDiagnostic GetExtractTokenErrorType(IPositionable positionable)
+            => DiagnosticBuilder.ForPosition(positionable).UnparseableJsonType();
+
 }

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -4,15 +4,6 @@ namespace Bicep.Core.Semantics
 {
     public static class JsonObjectParser : ObjectParser
     {
-        public static JToken ExtractTokenFromObject(string fileContent)
-        {
-            if (JsonObjectParser.ExtractTokenFromObject(fileContent) is not { } token)
-            {
-                // Instead of catching and returning the JSON parse exception, we simply return a generic error.
-                // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
-                return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[0]).UnparseableJsonType()));
-            }
-            return token;
-        }
+        public static JToken ExtractTokenFromObject(string fileContent) => JsonObjectParser.ExtractTokenFromObject(fileContent);
     }
 }

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -4,8 +4,6 @@ namespace Bicep.Core.Semantics
 {
     public static class JsonObjectParser : ObjectParser
     {
-        public static JToken ExtractTokenFromObject(string fileContent)
-        {
-            return fileContent.TryFromJson<JToken>();
-        }
+        public static JToken ExtractTokenFromObject(string fileContent) => fileContent.TryFromJson<JToken>();
+    }
 }

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -1,0 +1,11 @@
+using SharpYaml.Serialization;
+
+namespace Bicep.Core.Semantics
+{
+    public static class JsonObjectParser : ObjectParser
+    {
+        public static JToken ExtractTokenFromObject(string fileContent)
+        {
+            return fileContent.TryFromJson<JToken>();
+        }
+}

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -1,9 +1,11 @@
+using Microsoft.WindowsAzure.ResourceStack.Common.Json;
+using Newtonsoft.Json.Linq;
 using SharpYaml.Serialization;
 
 namespace Bicep.Core.Semantics
 {
-    public static class JsonObjectParser : ObjectParser
+    public class JsonObjectParser : ObjectParser
     {
-        public static JToken ExtractTokenFromObject(string fileContent) => JsonObjectParser.ExtractTokenFromObject(fileContent);
+        override public JToken ExtractTokenFromObject(string fileContent) => fileContent.TryFromJson<JToken>();
     }
 }

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -1,11 +1,17 @@
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Parsing;
+using Bicep.Core.TypeSystem;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 using Newtonsoft.Json.Linq;
-using SharpYaml.Serialization;
 
 namespace Bicep.Core.Semantics
 {
     public class JsonObjectParser : ObjectParser
     {
         override public JToken ExtractTokenFromObject(string fileContent) => fileContent.TryFromJson<JToken>();
+        override public ErrorType GetError(IPositionable positionable)
+        {
+            return ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).UnparseableJsonType());
+        }
     }
 }

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -8,10 +8,9 @@ namespace Bicep.Core.Semantics
 {
     public class JsonObjectParser : ObjectParser
     {
-        override public JToken ExtractTokenFromObject(string fileContent) => fileContent.TryFromJson<JToken>();
-        override public ErrorType GetParsingError(IPositionable positionable)
-        {
-            return ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).UnparseableJsonType());
-        }
+        override public JToken ExtractTokenFromObject(string fileContent)
+            => fileContent.TryFromJson<JToken>();
+        override public ErrorType GetExtractTokenError(IPositionable positionable)
+            => ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).UnparseableJsonType());
     }
 }

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -4,6 +4,15 @@ namespace Bicep.Core.Semantics
 {
     public static class JsonObjectParser : ObjectParser
     {
-        public static JToken ExtractTokenFromObject(string fileContent) => fileContent.TryFromJson<JToken>();
+        public static JToken ExtractTokenFromObject(string fileContent)
+        {
+            if (JsonObjectParser.ExtractTokenFromObject(fileContent) is not { } token)
+            {
+                // Instead of catching and returning the JSON parse exception, we simply return a generic error.
+                // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
+                return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[0]).UnparseableJsonType()));
+            }
+            return token;
+        }
     }
 }

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1063,10 +1063,12 @@ namespace Bicep.Core.Semantics.Namespaces
                 tokenSelectorPath = tokenSelectorType.RawStringValue;
             }
 
-            return TryLoadTextContentFromFile(binder, fileResolver, diagnostics, (arguments[0], argumentTypes[0]), arguments.Length > 2 ? (arguments[2], argumentTypes[2]) : null, out var fileContent, out var errorDiagnostic, LanguageConstants.MaxJsonFileCharacterLimit)
-                && objectParser.TryExtractFromObject(fileContent, tokenSelectorPath, arguments[1], out errorDiagnostic, out var token)
-                ? new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token))
-                : new(ErrorType.Create(errorDiagnostic));
+            if (TryLoadTextContentFromFile(binder, fileResolver, diagnostics, (arguments[0], argumentTypes[0]), arguments.Length > 2 ? (arguments[2], argumentTypes[2]) : null, out var fileContent, out var errorDiagnostic, LanguageConstants.MaxJsonFileCharacterLimit)
+                && objectParser.TryExtractFromObject(fileContent, tokenSelectorPath, arguments[1], out errorDiagnostic, out var token))
+            {
+                return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
+            }
+            return new(ErrorType.Create(errorDiagnostic));
         }
         // [Obsolete("This method has been replaced by ExtractTokenFromObject which supports both YAML and JSON")]
         // public static JToken OldExtractTokenFromObject(string fileContent)

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1076,7 +1076,15 @@ namespace Bicep.Core.Semantics.Namespaces
 
             if (tokenSelectorPath is not null)
             {
-                token = JsonObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
+                try
+                {
+                    token = JsonObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
+                }
+                catch (JsonException)
+                {
+                    //path is invalid or user hasn't finished typing it yet
+                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
+                }
             }
 
             return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
@@ -1113,7 +1121,15 @@ namespace Bicep.Core.Semantics.Namespaces
 
             if (tokenSelectorPath is not null)
             {
-                token = YamlObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
+                try
+                {
+                    token = YamlObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
+                }
+                catch (JsonException)
+                {
+                    //path is invalid or user hasn't finished typing it yet
+                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
+                }
             }
 
             return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1076,7 +1076,7 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 // Instead of catching and returning the YML parse exception, we simply return a generic error.
                 // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
-                return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[0]).UnparseableYamlType()));
+                return new(objectParser.GetParsingError(arguments[0]));
             }
 
             if (tokenSelectorPath is not null)
@@ -1088,7 +1088,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 catch (JsonException)
                 {
                     //path is invalid or user hasn't finished typing it yet
-                    return new(objectParser.GetError(arguments[1]));
+                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
                 }
             }
 

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1063,13 +1063,13 @@ namespace Bicep.Core.Semantics.Namespaces
                 tokenSelectorPath = tokenSelectorType.RawStringValue;
             }
             if (TryLoadTextContentFromFile(binder, fileResolver, diagnostics, (arguments[0], argumentTypes[0]), arguments.Length > 2 ? (arguments[2], argumentTypes[2]) : null, out var fileContent, out var errorDiagnostic, LanguageConstants.MaxJsonFileCharacterLimit)
-                && objectParser.TryExtractFromObject(fileContent, arguments[1], out errorDiagnostic, out var token)
-                && objectParser.TryExtractFromTokenByPath(token, tokenSelectorPath, arguments[1], out errorDiagnostic, out token))
+                && objectParser.TryExtractFromObject(fileContent, tokenSelectorPath, arguments[1], out errorDiagnostic, out var token))
             {
                 return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
             }
             return new(ErrorType.Create(errorDiagnostic));
         }
+
         // [Obsolete("This method has been replaced by ExtractTokenFromObject which supports both YAML and JSON")]
         // public static JToken OldExtractTokenFromObject(string fileContent)
         // {

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -17,8 +17,7 @@ using Bicep.Core.Intermediate;
 using Bicep.Core.Modules;
 using Bicep.Core.Parsing;
 using Bicep.Core.Syntax;
-using Bicep.Core.Semantics.JsonObjectParser;
-using Bicep.Core.Semantics.YamlObjectParser;
+using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem;
 using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
@@ -1067,7 +1066,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 return new(ErrorType.Create(errorDiagnostic));
             }
 
-            if (JsonObjectParser.ExtractTokenFromObject(fileContent) is not { } token)
+            if (new JsonObjectParser().ExtractTokenFromObject(fileContent) is not { } token)
             {
                 // Instead of catching and returning the JSON parse exception, we simply return a generic error.
                 // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
@@ -1078,7 +1077,7 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 try
                 {
-                    token = JsonObjectParser.ExtractTokenFromObjectByPath(token, tokenSelectorPath);
+                    token = new YamlObjectParser().ExtractTokenFromObjectByPath(token, tokenSelectorPath);
                 }
                 catch (JsonException)
                 {
@@ -1112,7 +1111,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 return new(ErrorType.Create(errorDiagnostic));
             }
 
-            if (YamlObjectParser.ExtractTokenFromObject(fileContent) is not { } token)
+            if (new YamlObjectParser().ExtractTokenFromObject(fileContent) is not { } token)
             {
                 // Instead of catching and returning the YML parse exception, we simply return a generic error.
                 // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
@@ -1123,7 +1122,7 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 try
                 {
-                    token = YamlObjectParser.ExtractTokenFromObjectByPath(token, tokenSelectorPath);
+                    token = new YamlObjectParser().ExtractTokenFromObjectByPath(token, tokenSelectorPath);
                 }
                 catch (JsonException)
                 {

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1062,37 +1062,13 @@ namespace Bicep.Core.Semantics.Namespaces
                 }
                 tokenSelectorPath = tokenSelectorType.RawStringValue;
             }
-            if (!TryLoadTextContentFromFile(binder, fileResolver, diagnostics,
-                    (arguments[0], argumentTypes[0]),
-                    arguments.Length > 2 ? (arguments[2], argumentTypes[2]) : null,
-                    out var fileContent,
-                    out var errorDiagnostic,
-                    LanguageConstants.MaxJsonFileCharacterLimit))
+            if (TryLoadTextContentFromFile(binder, fileResolver, diagnostics, (arguments[0], argumentTypes[0]), arguments.Length > 2 ? (arguments[2], argumentTypes[2]) : null, out var fileContent, out var errorDiagnostic, LanguageConstants.MaxJsonFileCharacterLimit)
+                && objectParser.TryExtractFromObject(fileContent, arguments[1], out errorDiagnostic, out var token)
+                && objectParser.TryExtractFromTokenByPath(token, tokenSelectorPath, arguments[1], out errorDiagnostic, out token))
             {
-                return new(ErrorType.Create(errorDiagnostic));
+                return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
             }
-
-            if (objectParser.ExtractTokenFromObject(fileContent) is not { } token)
-            {
-                // Instead of catching and returning the YML parse exception, we simply return a generic error.
-                // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
-                return new(objectParser.GetExtractTokenError(arguments[0]));
-            }
-
-            if (tokenSelectorPath is not null)
-            {
-                try
-                {
-                    token = objectParser.ExtractTokenFromObjectByPath(token, tokenSelectorPath);
-                }
-                catch (JsonException)
-                {
-                    //path is invalid or user hasn't finished typing it yet
-                    return new(objectParser.GetExtractTokenFromPathError(arguments[1]));
-                }
-            }
-
-            return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
+            return new(ErrorType.Create(errorDiagnostic));
         }
         // [Obsolete("This method has been replaced by ExtractTokenFromObject which supports both YAML and JSON")]
         // public static JToken OldExtractTokenFromObject(string fileContent)

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1067,8 +1067,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 return new(ErrorType.Create(errorDiagnostic));
             }
 
-            var jsonObjectParser = new JsonObjectParser();
-            if (jsonObjectParser.ExtractTokenFromObject(fileContent) is not { } token)
+            if (JsonObjectParser.ExtractTokenFromObject(fileContent) is not { } token)
             {
                 // Instead of catching and returning the JSON parse exception, we simply return a generic error.
                 // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
@@ -1077,7 +1076,7 @@ namespace Bicep.Core.Semantics.Namespaces
 
             if (tokenSelectorPath is not null)
             {
-                token = jsonObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
+                token = JsonObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
             }
 
             return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
@@ -1105,8 +1104,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 return new(ErrorType.Create(errorDiagnostic));
             }
 
-            var yamlObjectParser = new YamlObjectParser();
-            if (yamlObjectParser.ExtractTokenFromObject(fileContent) is not { } token)
+            if (YamlObjectParser.ExtractTokenFromObject(fileContent) is not { } token)
             {
                 // Instead of catching and returning the YML parse exception, we simply return a generic error.
                 // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
@@ -1115,7 +1113,7 @@ namespace Bicep.Core.Semantics.Namespaces
 
             if (tokenSelectorPath is not null)
             {
-                token = yamlObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
+                token = YamlObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
             }
 
             return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
@@ -1171,17 +1169,17 @@ namespace Bicep.Core.Semantics.Namespaces
 
         }*/
 
-        public static JToken ExtractTokenFromObject(string fileContent)
-        {
-            // Replace // with # unless in quotes
-            // fileContent = Regex.Replace(fileContent, @"//+(?=([^""\\]*(\\.|""([^""\\]*\\.)*[^""\\]*""))*[^""]*$)", "#", RegexOptions.Singleline);
-            // Manually fix multi-line comment with regex by appending # and manually fix first line
-            // fileContent = Regex.Replace(fileContent, @"(/\*.+?\*/)", m => m.Value.Replace("\n", "\n#"), RegexOptions.Singleline).Replace("/*", "# /*");
-            /*JToken jToken = JToken.FromObject(Deserializer.Deserialize<Dictionary<string, object>>(fileContent));*/
-            /*CastPrimiteTypes(jToken);*/
-            /*return jToken;*/
-            return JToken.FromObject(new Serializer().Deserialize(fileContent)!);
-        }
+        // public static JToken ExtractTokenFromObject(string fileContent)
+        // {
+        //     // Replace // with # unless in quotes
+        //     // fileContent = Regex.Replace(fileContent, @"//+(?=([^""\\]*(\\.|""([^""\\]*\\.)*[^""\\]*""))*[^""]*$)", "#", RegexOptions.Singleline);
+        //     // Manually fix multi-line comment with regex by appending # and manually fix first line
+        //     // fileContent = Regex.Replace(fileContent, @"(/\*.+?\*/)", m => m.Value.Replace("\n", "\n#"), RegexOptions.Singleline).Replace("/*", "# /*");
+        //     /*JToken jToken = JToken.FromObject(Deserializer.Deserialize<Dictionary<string, object>>(fileContent));*/
+        //     /*CastPrimiteTypes(jToken);*/
+        //     /*return jToken;*/
+        //     return JToken.FromObject(new Serializer().Deserialize(fileContent)!);
+        // }
 
         private static bool TryLoadTextContentFromFile(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, (FunctionArgumentSyntax syntax, TypeSymbol typeSymbol) filePathArgument, (FunctionArgumentSyntax syntax, TypeSymbol typeSymbol)? encodingArgument, [NotNullWhen(true)] out string? fileContent, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, int maxCharacters = -1)
         {

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -17,6 +17,8 @@ using Bicep.Core.Intermediate;
 using Bicep.Core.Modules;
 using Bicep.Core.Parsing;
 using Bicep.Core.Syntax;
+using Bicep.Core.Semantics.JsonObjectParser;
+using Bicep.Core.Semantics.YamlObjectParser;
 using Bicep.Core.TypeSystem;
 using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
@@ -1065,7 +1067,8 @@ namespace Bicep.Core.Semantics.Namespaces
                 return new(ErrorType.Create(errorDiagnostic));
             }
 
-            if (fileContent.TryFromJson<JToken>() is not { } token)
+            var jsonObjectParser = new JsonObjectParser();
+            if (jsonObjectParser.ExtractTokenFromObject(fileContent) is not { } token)
             {
                 // Instead of catching and returning the JSON parse exception, we simply return a generic error.
                 // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
@@ -1074,30 +1077,7 @@ namespace Bicep.Core.Semantics.Namespaces
 
             if (tokenSelectorPath is not null)
             {
-                try
-                {
-                    var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();
-                    switch (selectTokens.Count)
-                    {
-                        case 0:
-                            return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
-                        case 1:
-                            token = selectTokens.First();
-                            break;
-                        default:
-                            token = new JArray();
-                            foreach (var selectToken in selectTokens)
-                            {
-                                ((JArray)token).Add(selectToken);
-                            }
-                            break;
-                    }
-                }
-                catch (JsonException)
-                {
-                    //path is invalid or user hasn't finished typing it yet
-                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
-                }
+                token = jsonObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
             }
 
             return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
@@ -1125,7 +1105,8 @@ namespace Bicep.Core.Semantics.Namespaces
                 return new(ErrorType.Create(errorDiagnostic));
             }
 
-            if (ExtractTokenFromObject(fileContent) is not { } token)
+            var yamlObjectParser = new YamlObjectParser();
+            if (yamlObjectParser.ExtractTokenFromObject(fileContent) is not { } token)
             {
                 // Instead of catching and returning the YML parse exception, we simply return a generic error.
                 // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
@@ -1134,31 +1115,7 @@ namespace Bicep.Core.Semantics.Namespaces
 
             if (tokenSelectorPath is not null)
             {
-                try
-                {
-                    var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();
-                    switch (selectTokens.Count)
-                    {
-                        case 0:
-                            return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
-                        case 1:
-                            token = selectTokens.First();
-                            break;
-                        default:
-                            var arrayToken = new JArray();
-                            token = arrayToken;
-                            foreach (var selectToken in selectTokens)
-                            {
-                                arrayToken.Add(selectToken);
-                            }
-                            break;
-                    }
-                }
-                catch (JsonException)
-                {
-                    //path is invalid or user hasn't finished typing it yet
-                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
-                }
+                token = yamlObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
             }
 
             return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1062,14 +1062,12 @@ namespace Bicep.Core.Semantics.Namespaces
                 }
                 tokenSelectorPath = tokenSelectorType.RawStringValue;
             }
-            if (TryLoadTextContentFromFile(binder, fileResolver, diagnostics, (arguments[0], argumentTypes[0]), arguments.Length > 2 ? (arguments[2], argumentTypes[2]) : null, out var fileContent, out var errorDiagnostic, LanguageConstants.MaxJsonFileCharacterLimit)
-                && objectParser.TryExtractFromObject(fileContent, tokenSelectorPath, arguments[1], out errorDiagnostic, out var token))
-            {
-                return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
-            }
-            return new(ErrorType.Create(errorDiagnostic));
-        }
 
+            return TryLoadTextContentFromFile(binder, fileResolver, diagnostics, (arguments[0], argumentTypes[0]), arguments.Length > 2 ? (arguments[2], argumentTypes[2]) : null, out var fileContent, out var errorDiagnostic, LanguageConstants.MaxJsonFileCharacterLimit)
+                && objectParser.TryExtractFromObject(fileContent, tokenSelectorPath, arguments[1], out errorDiagnostic, out var token)
+                ? new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token))
+                : new(ErrorType.Create(errorDiagnostic));
+        }
         // [Obsolete("This method has been replaced by ExtractTokenFromObject which supports both YAML and JSON")]
         // public static JToken OldExtractTokenFromObject(string fileContent)
         // {

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1045,51 +1045,12 @@ namespace Bicep.Core.Semantics.Namespaces
         }
 
         private static FunctionResult LoadJsonContentResultBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
-        {
-            var arguments = functionCall.Arguments.ToImmutableArray();
-            string? tokenSelectorPath = null;
-            if (arguments.Length > 1)
-            {
-                if (argumentTypes[1] is not StringLiteralType tokenSelectorType)
-                {
-                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).CompileTimeConstantRequired()));
-                }
-                tokenSelectorPath = tokenSelectorType.RawStringValue;
-            }
-            if (!TryLoadTextContentFromFile(binder, fileResolver, diagnostics,
-                    (arguments[0], argumentTypes[0]),
-                    arguments.Length > 2 ? (arguments[2], argumentTypes[2]) : null,
-                    out var fileContent,
-                    out var errorDiagnostic,
-                    LanguageConstants.MaxJsonFileCharacterLimit))
-            {
-                return new(ErrorType.Create(errorDiagnostic));
-            }
-
-            if (new JsonObjectParser().ExtractTokenFromObject(fileContent) is not { } token)
-            {
-                // Instead of catching and returning the JSON parse exception, we simply return a generic error.
-                // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
-                return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[0]).UnparseableJsonType()));
-            }
-
-            if (tokenSelectorPath is not null)
-            {
-                try
-                {
-                    token = new YamlObjectParser().ExtractTokenFromObjectByPath(token, tokenSelectorPath);
-                }
-                catch (JsonException)
-                {
-                    //path is invalid or user hasn't finished typing it yet
-                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
-                }
-            }
-
-            return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
-        }
+            => LoadContentResultBuilder(new JsonObjectParser(), binder, fileResolver, diagnostics, functionCall, argumentTypes);
 
         private static FunctionResult LoadYamlContentResultBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
+            => LoadContentResultBuilder(new YamlObjectParser(), binder, fileResolver, diagnostics, functionCall, argumentTypes);
+
+        private static FunctionResult LoadContentResultBuilder(ObjectParser objectParser, IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
         {
             var arguments = functionCall.Arguments.ToImmutableArray();
             string? tokenSelectorPath = null;
@@ -1111,7 +1072,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 return new(ErrorType.Create(errorDiagnostic));
             }
 
-            if (new YamlObjectParser().ExtractTokenFromObject(fileContent) is not { } token)
+            if (objectParser.ExtractTokenFromObject(fileContent) is not { } token)
             {
                 // Instead of catching and returning the YML parse exception, we simply return a generic error.
                 // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
@@ -1122,18 +1083,17 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 try
                 {
-                    token = new YamlObjectParser().ExtractTokenFromObjectByPath(token, tokenSelectorPath);
+                    token = objectParser.ExtractTokenFromObjectByPath(token, tokenSelectorPath);
                 }
                 catch (JsonException)
                 {
                     //path is invalid or user hasn't finished typing it yet
-                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
+                    return new(objectParser.GetError(arguments[1]));
                 }
             }
 
             return new(ConvertJsonToBicepType(token), ConvertJsonToExpression(token));
         }
-
         // [Obsolete("This method has been replaced by ExtractTokenFromObject which supports both YAML and JSON")]
         // public static JToken OldExtractTokenFromObject(string fileContent)
         // {

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1076,7 +1076,7 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 // Instead of catching and returning the YML parse exception, we simply return a generic error.
                 // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
-                return new(objectParser.GetParsingError(arguments[0]));
+                return new(objectParser.GetExtractTokenError(arguments[0]));
             }
 
             if (tokenSelectorPath is not null)
@@ -1088,7 +1088,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 catch (JsonException)
                 {
                     //path is invalid or user hasn't finished typing it yet
-                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
+                    return new(objectParser.GetExtractTokenFromPathError(arguments[1]));
                 }
             }
 

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1078,7 +1078,7 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 try
                 {
-                    token = JsonObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
+                    token = JsonObjectParser.ExtractTokenFromObjectByPath(token, tokenSelectorPath);
                 }
                 catch (JsonException)
                 {
@@ -1123,7 +1123,7 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 try
                 {
-                    token = YamlObjectParser.ExtractTokenFromObject(token, tokenSelectorPath);
+                    token = YamlObjectParser.ExtractTokenFromObjectByPath(token, tokenSelectorPath);
                 }
                 catch (JsonException)
                 {

--- a/src/Bicep.Core/Semantics/ObjectParser.cs
+++ b/src/Bicep.Core/Semantics/ObjectParser.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Collections.Immutable;
-using Bicep.Core.Semantics.Namespaces;
-using Bicep.Core.Syntax;
-using Bicep.Core.TypeSystem;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Bicep.Core.Semantics
 {
-    public abstract class ObjectParser : IParser
+    public abstract class ObjectParser : IObjectParser
     {
         public abstract JToken ExtractTokenFromObject(string fileContent);
 
@@ -16,10 +15,8 @@ namespace Bicep.Core.Semantics
             var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();
             switch (selectTokens.Count)
             {
-                case 0:
-                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
-                case 1:
-                    return selectTokens.First();
+                case 0: throw new JsonException($"Required length greater than 0.");
+                case 1: return selectTokens.First();
                 default:
                     var arrayToken = new JArray();
                     foreach (var selectToken in selectTokens)

--- a/src/Bicep.Core/Semantics/ObjectParser.cs
+++ b/src/Bicep.Core/Semantics/ObjectParser.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Linq;
+using Bicep.Core.Parsing;
+using Bicep.Core.TypeSystem;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -9,7 +11,7 @@ namespace Bicep.Core.Semantics
     public abstract class ObjectParser : IObjectParser
     {
         public abstract JToken ExtractTokenFromObject(string fileContent);
-
+        public abstract ErrorType GetError(IPositionable positionable);
         public JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath)
         {
             var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();

--- a/src/Bicep.Core/Semantics/ObjectParser.cs
+++ b/src/Bicep.Core/Semantics/ObjectParser.cs
@@ -13,28 +13,20 @@ namespace Bicep.Core.Semantics
 
         public JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath)
         {
-            try
+            var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();
+            switch (selectTokens.Count)
             {
-                var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();
-                switch (selectTokens.Count)
-                {
-                    case 0:
-                        return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
-                    case 1:
-                        return selectTokens.First();
-                    default:
-                        var arrayToken = new JArray();
-                        foreach (var selectToken in selectTokens)
-                        {
-                            arrayToken.Add(selectToken);
-                        }
-                        return arrayToken;
-                }
-            }
-            catch (JsonException)
-            {
-                //path is invalid or user hasn't finished typing it yet
-                return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
+                case 0:
+                    return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
+                case 1:
+                    return selectTokens.First();
+                default:
+                    var arrayToken = new JArray();
+                    foreach (var selectToken in selectTokens)
+                    {
+                        arrayToken.Add(selectToken);
+                    }
+                    return arrayToken;
             }
         }
     }

--- a/src/Bicep.Core/Semantics/ObjectParser.cs
+++ b/src/Bicep.Core/Semantics/ObjectParser.cs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Intermediate;
 using Bicep.Core.Parsing;
 using Bicep.Core.TypeSystem;
 using Newtonsoft.Json;
@@ -11,21 +16,20 @@ namespace Bicep.Core.Semantics
     public abstract class ObjectParser : IObjectParser
     {
         public abstract JToken ExtractTokenFromObject(string fileContent);
-        public abstract ErrorType GetParsingError(IPositionable positionable);
+        public abstract ErrorType GetExtractTokenError(IPositionable positionable);
+
+        public ErrorType GetExtractTokenFromPathError(IPositionable positionable)
+            =>  ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).NoJsonTokenOnPathOrPathInvalid());
+
         public JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath)
         {
             var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();
+
             switch (selectTokens.Count)
             {
                 case 0: throw new JsonException($"Required length greater than 0.");
                 case 1: return selectTokens.First();
-                default:
-                    var arrayToken = new JArray();
-                    foreach (var selectToken in selectTokens)
-                    {
-                        arrayToken.Add(selectToken);
-                    }
-                    return arrayToken;
+                default: return new JArray(selectTokens);
             }
         }
     }

--- a/src/Bicep.Core/Semantics/ObjectParser.cs
+++ b/src/Bicep.Core/Semantics/ObjectParser.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+
+namespace Bicep.Core.Semantics
+{
+    public abstract class ObjectParser : IParser
+    {
+        public abstract JToken ExtractTokenFromObject(string fileContent);
+
+        public JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath)
+        {
+            try
+            {
+                var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();
+                switch (selectTokens.Count)
+                {
+                    case 0:
+                        return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
+                    case 1:
+                        return selectTokens.First();
+                    default:
+                        var arrayToken = new JArray();
+                        foreach (var selectToken in selectTokens)
+                        {
+                            arrayToken.Add(selectToken);
+                        }
+                        return arrayToken;
+                }
+            }
+            catch (JsonException)
+            {
+                //path is invalid or user hasn't finished typing it yet
+                return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
+            }
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/ObjectParser.cs
+++ b/src/Bicep.Core/Semantics/ObjectParser.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.Semantics
     public abstract class ObjectParser : IObjectParser
     {
         public abstract JToken ExtractTokenFromObject(string fileContent);
-        public abstract ErrorType GetError(IPositionable positionable);
+        public abstract ErrorType GetParsingError(IPositionable positionable);
         public JToken ExtractTokenFromObjectByPath(JToken token, string tokenSelectorPath)
         {
             var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();

--- a/src/Bicep.Core/Semantics/ObjectParser.cs
+++ b/src/Bicep.Core/Semantics/ObjectParser.cs
@@ -17,11 +17,24 @@ namespace Bicep.Core.Semantics
 {
     public abstract class ObjectParser : IObjectParser
     {
+        public bool TryExtractFromObject(string fileContent, string? tokenSelectorPath, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken){
+            errorDiagnostic = null;
+            newToken = this.ExtractTokenFromObject(fileContent);
+            if (newToken is not { })
+            {
+                // Instead of catching and returning the YML parse exception, we simply return a generic error.
+                // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
+                errorDiagnostic = this.GetExtractTokenErrorType(positionable);
+                return false;
+            }
+            if (tokenSelectorPath is not null){
+                return this.TryExtractFromTokenByPath(newToken, tokenSelectorPath, positionable, out errorDiagnostic, out newToken);
+            }
+            return true;
+        }
         public abstract JToken ExtractTokenFromObject(string fileContent);
-
         public abstract ErrorDiagnostic GetExtractTokenErrorType(IPositionable positionable);
-
-        public bool TryExtractFromTokenByPath(JToken token, string? tokenSelectorPath, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken)
+        public bool TryExtractFromTokenByPath(JToken token, string tokenSelectorPath, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken)
         {
             newToken = token;
             errorDiagnostic = null;
@@ -49,17 +62,5 @@ namespace Bicep.Core.Semantics
             return true;
         }
 
-        public bool TryExtractFromObject(string fileContent, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken){
-            errorDiagnostic = null;
-            newToken = this.ExtractTokenFromObject(fileContent);
-            if (newToken is not { } token)
-            {
-                // Instead of catching and returning the YML parse exception, we simply return a generic error.
-                // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
-                errorDiagnostic = this.GetExtractTokenErrorType(positionable);
-                return false;
-            }
-            return true;
-        }
     }
 }

--- a/src/Bicep.Core/Semantics/YamlObjectParser.cs
+++ b/src/Bicep.Core/Semantics/YamlObjectParser.cs
@@ -1,0 +1,12 @@
+using SharpYaml.Serialization;
+
+namespace Bicep.Core.Semantics
+{
+    public static class YamlObjectParser : ObjectParser
+    {
+        public static JToken ExtractTokenFromObject(string fileContent)
+        {
+            return JToken.FromObject(new Serializer().Deserialize(fileContent)!);
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/YamlObjectParser.cs
+++ b/src/Bicep.Core/Semantics/YamlObjectParser.cs
@@ -1,9 +1,10 @@
+using Newtonsoft.Json.Linq;
 using SharpYaml.Serialization;
 
 namespace Bicep.Core.Semantics
 {
-    public static class YamlObjectParser : ObjectParser
+    public class YamlObjectParser : ObjectParser
     {
-        public static JToken ExtractTokenFromObject(string fileContent) => JToken.FromObject(new Serializer().Deserialize(fileContent)!);
+        override public JToken ExtractTokenFromObject(string fileContent) => JToken.FromObject(new Serializer().Deserialize(fileContent)!);
     }
 }

--- a/src/Bicep.Core/Semantics/YamlObjectParser.cs
+++ b/src/Bicep.Core/Semantics/YamlObjectParser.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Parsing;
 using Bicep.Core.TypeSystem;
@@ -11,7 +12,8 @@ namespace Bicep.Core.Semantics
         override public JToken ExtractTokenFromObject(string fileContent)
             => JToken.FromObject(new Serializer().Deserialize(fileContent)!);
 
-        override public ErrorType GetExtractTokenError(IPositionable positionable)
-            => ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).UnparseableYamlType());
+        override public ErrorDiagnostic GetExtractTokenErrorType(IPositionable positionable)
+            => DiagnosticBuilder.ForPosition(positionable).UnparseableYamlType();
+
     }
 }

--- a/src/Bicep.Core/Semantics/YamlObjectParser.cs
+++ b/src/Bicep.Core/Semantics/YamlObjectParser.cs
@@ -10,7 +10,7 @@ namespace Bicep.Core.Semantics
     {
         override public JToken ExtractTokenFromObject(string fileContent) => JToken.FromObject(new Serializer().Deserialize(fileContent)!);
 
-        override public ErrorType GetError(IPositionable positionable)
+        override public ErrorType GetParsingError(IPositionable positionable)
         {
             return ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).UnparseableYamlType());
         }

--- a/src/Bicep.Core/Semantics/YamlObjectParser.cs
+++ b/src/Bicep.Core/Semantics/YamlObjectParser.cs
@@ -8,11 +8,10 @@ namespace Bicep.Core.Semantics
 {
     public class YamlObjectParser : ObjectParser
     {
-        override public JToken ExtractTokenFromObject(string fileContent) => JToken.FromObject(new Serializer().Deserialize(fileContent)!);
+        override public JToken ExtractTokenFromObject(string fileContent)
+            => JToken.FromObject(new Serializer().Deserialize(fileContent)!);
 
-        override public ErrorType GetParsingError(IPositionable positionable)
-        {
-            return ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).UnparseableYamlType());
-        }
+        override public ErrorType GetExtractTokenError(IPositionable positionable)
+            => ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).UnparseableYamlType());
     }
 }

--- a/src/Bicep.Core/Semantics/YamlObjectParser.cs
+++ b/src/Bicep.Core/Semantics/YamlObjectParser.cs
@@ -1,3 +1,6 @@
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Parsing;
+using Bicep.Core.TypeSystem;
 using Newtonsoft.Json.Linq;
 using SharpYaml.Serialization;
 
@@ -6,5 +9,10 @@ namespace Bicep.Core.Semantics
     public class YamlObjectParser : ObjectParser
     {
         override public JToken ExtractTokenFromObject(string fileContent) => JToken.FromObject(new Serializer().Deserialize(fileContent)!);
+
+        override public ErrorType GetError(IPositionable positionable)
+        {
+            return ErrorType.Create(DiagnosticBuilder.ForPosition(positionable).UnparseableYamlType());
+        }
     }
 }

--- a/src/Bicep.Core/Semantics/YamlObjectParser.cs
+++ b/src/Bicep.Core/Semantics/YamlObjectParser.cs
@@ -4,9 +4,6 @@ namespace Bicep.Core.Semantics
 {
     public static class YamlObjectParser : ObjectParser
     {
-        public static JToken ExtractTokenFromObject(string fileContent)
-        {
-            return JToken.FromObject(new Serializer().Deserialize(fileContent)!);
-        }
+        public static JToken ExtractTokenFromObject(string fileContent) => JToken.FromObject(new Serializer().Deserialize(fileContent)!);
     }
 }


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
