### PR TITLE
Danay1999/yaml (#14)

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -2001,6 +2001,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -720,6 +720,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "2jBenJ6QN0mj8G3ohrNO/uNhA92OJYsQFuI5dJ4zM/HauVoC/oJzK1sCVlUaVUpuXpHUa/k1waXVkkBR2luP/w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1817,6 +1822,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -662,6 +662,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "2jBenJ6QN0mj8G3ohrNO/uNhA92OJYsQFuI5dJ4zM/HauVoC/oJzK1sCVlUaVUpuXpHUa/k1waXVkkBR2luP/w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1754,6 +1759,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.Core.IntegrationTests/Scenarios/LoadFunctionsTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/LoadFunctionsTests.cs
@@ -31,7 +31,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 ";
         private static readonly string B64_TEXT_CONTENT = Convert.ToBase64String(Encoding.UTF8.GetBytes(TEXT_CONTENT));
-        public enum FunctionCase { loadTextContent, loadFileAsBase64, loadJsonContent }
+        public enum FunctionCase { loadTextContent, loadFileAsBase64, loadJsonContent, loadYamlContent }
         private static string ExpectedResult(FunctionCase function) => function switch
         {
             FunctionCase.loadTextContent => TEXT_CONTENT,
@@ -285,6 +285,14 @@ var files = [
   encoding: encoding
  }
 ]", "files[0].name", "'$'", "files[0].encoding", DisplayName = "loadJsonContent: encoding param as object property in array")]
+        [DataRow(FunctionCase.loadYamlContent, @"param encoding string = 'us-ascii'
+var files = [
+    {
+        name: 'message.yaml'
+        path: '$'
+        encoding: encoding
+    }
+]", "files[0].name", "'$'", "files[0].encoding", DisplayName = "loadYamlContent: encoding param as object property in array")]
         public void LoadFunction_RequiresCompileTimeConstantArguments_Invalid(FunctionCase function, string declaration, params string[] args)
         {
             //notice - here we will not test actual loading file with given encoding - just the fact that bicep function accepts all .NET available encodings
@@ -446,6 +454,7 @@ output out string = script
         [DataRow(FunctionCase.loadTextContent)]
         [DataRow(FunctionCase.loadFileAsBase64)]
         [DataRow(FunctionCase.loadJsonContent)]
+        [DataRow(FunctionCase.loadYamlContent)]
         public void LoadFunction_FileDoesNotExist(FunctionCase function)
         {
             var (template, diags, _) = CompilationHelper.Compile(
@@ -793,5 +802,222 @@ var fileObj = loadJsonContent('file.json')
 "));
             }
         }
+
+        /**** loadYamlContent ****/
+        private const string TEST_YAML = @"propString: propStringValue
+popBoolTrue: true
+propBoolFalse: false
+propNull: null
+propInt: 1073741824
+propIntNegative: -1073741824
+propBigInt : 4611686018427387904
+propBigIntNegative : -4611686018427387904
+propFloat : 1.618033988749894
+propFloatNegative : -1.618033988749894
+propArrayString :
+- stringArray1
+- stringArray2
+- stringArray3
+propArrayInt :
+- 153584335
+- -5889645
+- 4611686018427387904
+propArrayFloat :
+- 1.61803398874
+- 3.14159265359
+- -1.73205080757
+propObject :
+    subObjectPropString: subObjectPropStringValue
+    subObjectPropBoolTrue: true
+    subObjectPropBoolFalse: false
+    subObjectPropNull: null
+    subObjectPropInt : 1234542113245
+    subObjectPropFloat : 1.618033988749894
+    subObjectPropArrayString :
+    - subObjectStringArray1
+    - subObjectStringArray2
+    - subObjectStringArray3
+    subObjectPropArrayInt :
+    - 153584335
+    - -5889645
+    - 4611686018427387904
+    subObjectPropArrayFloat :
+    - 1.61803398874
+    - 3.14159265359
+    - -1.73205080757
+";
+
+        private const string TEST_YAML_ARM = @"propString: propStringValue
+popBoolTrue: true
+propBoolFalse: false
+propNull: null
+propInt: 1073741824
+propIntNegative: -1073741824
+propBigInt: 4611686018427387904
+propBigIntNegative: -4611686018427387904
+propFloat: 1.618033988749894
+propFloatNegative: -1.618033988749894
+propArrayString:
+- stringArray1
+- stringArray2
+- stringArray3
+propArrayInt:
+- 153584335
+- -5889645
+- 4611686018427387904
+propArrayFloat:
+- 1.61803398874
+- 3.14159265359
+- -1.73205080757
+propObject:
+    subObjectPropString: subObjectPropStringValue
+    subObjectPropBoolTrue: true
+    subObjectPropBoolFalse: false
+    subObjectPropNull: null
+    subObjectPropInt: 1234542113245
+    subObjectPropFloat: 1.618033988749894
+    subObjectPropArrayString:
+    - subObjectStringArray1
+    - subObjectStringArray2
+    - subObjectStringArray3
+    subObjectPropArrayInt:
+    - 153584335
+    - -5889645
+    - 4611686018427387904
+    subObjectPropArrayFloat:
+    - 1.61803398874
+    - 3.14159265359
+    - -1.73205080757
+";
+        [TestMethod]
+        public void LoadYamlFunction()
+        {
+            var (template, diags, _) = CompilationHelper.Compile(
+    ("main.bicep", @"
+var fileObj = loadYamlContent('file.yaml')
+"),
+    ("file.yaml", TEST_YAML));
+
+            using (new AssertionScope())
+            {
+                template!.Should().NotBeNull();
+                diags.ExcludingLinterDiagnostics().Should().BeEmpty();
+            }
+            using (new AssertionScope())
+            {
+                template!.SelectToken("$.variables.fileObj").Should().DeepEqual("[variables('$fxv#0')]");
+                template!.SelectToken("$.variables['$fxv#0']").Should().DeepEqual(JToken.Parse(TEST_YAML_ARM));
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("$")]
+        [DataRow(".propObject")]
+        [DataRow(".propArrayFloat[0]")]
+        [DataRow(".propObject.subObjectPropString")]
+        [DataRow(".propObject.subObjectPropFloat")]
+        [DataRow(".propObject.subObjectPropFloat")]
+        [DataRow(".propObject.subObjectPropArrayInt[0]")]
+        public void LoadYamlFunction_withPath(string path)
+        {
+            var (template, diags, _) = CompilationHelper.Compile(
+    ("main.bicep", @"
+var fileObj = loadYamlContent('file.yaml', '" + path + @"')
+"),
+    ("file.yaml", TEST_YAML));
+
+            using (new AssertionScope())
+            {
+                template!.Should().NotBeNull();
+                diags.ExcludingLinterDiagnostics().Should().BeEmpty();
+            }
+            using (new AssertionScope())
+            {
+                template!.SelectToken("$.variables.fileObj").Should().DeepEqual("[variables('$fxv#0')]");
+                template!.SelectToken("$.variables['$fxv#0']").Should().DeepEqual(3.14159265359);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(".")]
+        [DataRow("[]")]
+        [DataRow("[0]")]
+        [DataRow("$.")]
+        [DataRow(".propObject[0]")]
+        [DataRow(".propArrayFloat[5]")]
+        [DataRow(".propObject/subObjectPropString")]
+        [DataRow(".propObj")]
+        public void LoadYamlFunction_withPath_errorWhenPathInvalidOrDoesNotExist(string path)
+        {
+            var (template, diags, _) = CompilationHelper.Compile(
+    ("main.bicep", @"
+var fileObj = loadYamlContent('file.yaml', '" + path + @"')
+"),
+    ("file.yaml", TEST_YAML));
+
+            using (new AssertionScope())
+            {
+                template!.Should().BeNull();
+                diags.ExcludingLinterDiagnostics().Should().BeEmpty();
+            }
+        }
+
+        private static CompilationHelper.CompilationResult CreateLoadYamlContentTestCompilation(string encodingName)
+        {
+            var encoding = LanguageConstants.SupportedEncodings.TryGetValue(encodingName, out var val) ? val : Encoding.UTF8;
+
+            var files = new Dictionary<Uri, MockFileData>
+            {
+                [new Uri("file:///main.bicep")] = new(@"
+var fileObj = loadYamlContent('file.yaml', '$', '" + encodingName + @"')
+"),
+                [new Uri("file:///file.yaml")] = new(TEST_YAML, encoding),
+            };
+
+            return CompilationHelper.Compile(new(), new InMemoryFileResolver(files), files.Keys, new Uri("file:///main.bicep"));
+        }
+
+        [DataTestMethod]
+        [DataRow("utf-8")]
+        [DataRow("utf-16BE")]
+        [DataRow("utf-16")]
+        [DataRow("us-ascii")]
+        [DataRow("iso-8859-1")]
+        public void LoadYamlContent_AcceptsAvailableEncoding(string encoding)
+        {
+            var (template, diags, _) = CreateLoadYamlContentTestCompilation(encoding);
+
+            using (new AssertionScope())
+            {
+                diags.ExcludingLinterDiagnostics().Should().BeEmpty();
+                template!.Should().NotBeNull();
+            }
+            using (new AssertionScope())
+            {
+                template!.SelectToken("$.variables.fileObj").Should().DeepEqual("[variables('$fxv#0')]");
+                template!.SelectToken("$.variables['$fxv#0']").Should().DeepEqual(3.14159265359);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("utf")]
+        [DataRow("utf-32be")]
+        [DataRow("utf-32le")]
+        [DataRow("utf-7")]
+        [DataRow("iso-8859-2")]
+        [DataRow("en-us")]
+        [DataRow("")]
+        public void LoadYamlContent_DisallowsUnknownEncoding(string encoding)
+        {
+            //notice - here we will not test actual loading file with given encoding - just the fact that bicep function accepts all .NET available encodings
+            var (template, diags, _) = CreateLoadYamlContentTestCompilation(encoding);
+
+            using (new AssertionScope())
+            {
+                template!.Should().BeNull();
+                diags.ExcludingLinterDiagnostics().Should().ContainSingleDiagnostic("BCP070", Diagnostics.DiagnosticLevel.Error, $"Argument of type \"'{encoding}'\" is not assignable to parameter of type \"{LanguageConstants.LoadTextContentEncodings}\".");
+            }
+        }
+
     }
 }

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -2001,6 +2001,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.Core.Samples/Files/Functions/sys.json
+++ b/src/Bicep.Core.Samples/Files/Functions/sys.json
@@ -939,6 +939,39 @@
     ]
   },
   {
+    "name": "loadYamlContent",
+    "description": "Loads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.",
+    "fixedParameters": [
+      {
+        "name": "filePath",
+        "description": "The path to the file that will be loaded.",
+        "type": "string",
+        "required": true
+      },
+      {
+        "name": "jsonPath",
+        "description": "JSONPath expression to narrow down the loaded file. If not provided, a root element indicator '$' is used",
+        "type": "string",
+        "required": false
+      },
+      {
+        "name": "encoding",
+        "description": "File encoding. If not provided, UTF-8 will be used.",
+        "type": "'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8'",
+        "required": false
+      }
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 3,
+    "flags": "generateIntermediateVariableAlways",
+    "typeSignature": "(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any",
+    "parameterTypeSignatures": [
+      "filePath: string",
+      "[jsonPath: string]",
+      "[encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']"
+    ]
+  },
+  {
     "name": "map",
     "description": "Applies a custom mapping function to each element of an array and returns the result array.",
     "fixedParameters": [

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/symbols.json
@@ -1537,6 +1537,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "lt",
     "kind": "variable",
     "detail": "lt",

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/sysFunctions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/sysFunctions.json
@@ -777,6 +777,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "map",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -1434,6 +1434,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "managementGroup",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -1434,6 +1434,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "managementGroup",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -882,6 +882,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "managementGroup",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -846,6 +846,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "managementGroup",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -832,6 +832,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "managementGroup",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/symbols.json
@@ -832,6 +832,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "managementGroup",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -1085,6 +1085,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "malformedModifier",
     "kind": "field",
     "detail": "malformedModifier",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -1085,6 +1085,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "malformedModifier",
     "kind": "field",
     "detail": "malformedModifier",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
@@ -1071,6 +1071,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "malformedModifier",
     "kind": "field",
     "detail": "malformedModifier",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -1089,6 +1089,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "malformedModifier",
     "kind": "field",
     "detail": "malformedModifier",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -3187,6 +3187,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -3151,6 +3151,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -3179,6 +3179,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -3410,6 +3410,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -3410,6 +3410,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -3410,6 +3410,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -3410,6 +3410,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -3172,6 +3172,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -3172,6 +3172,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -3172,6 +3172,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -3172,6 +3172,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -3658,6 +3658,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -3658,6 +3658,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -3658,6 +3658,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -3658,6 +3658,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -3165,6 +3165,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -3165,6 +3165,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -3165,6 +3165,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -3165,6 +3165,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -3158,6 +3158,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -3158,6 +3158,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -3158,6 +3158,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -3158,6 +3158,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -3137,6 +3137,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -3137,6 +3137,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -3280,6 +3280,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -3154,6 +3154,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -3168,6 +3168,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -3168,6 +3168,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -3168,6 +3168,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -3218,6 +3218,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -3182,6 +3182,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -3168,6 +3168,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -1224,6 +1224,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "loopExpression",
     "kind": "variable",
     "detail": "loopExpression",

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
@@ -1260,6 +1260,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "loopExpression",
     "kind": "variable",
     "detail": "loopExpression",

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -1242,6 +1242,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "loopExpression",
     "kind": "variable",
     "detail": "loopExpression",

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/Assets/test.yaml.txt
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/Assets/test.yaml.txt
@@ -1,0 +1,16 @@
+string: someVal 
+int: 123
+bool: true
+arrayInt:
+- 1
+- 2
+arrayString:
+- someVal
+- someVal2
+arrayBool:
+- true
+- true
+object:
+  nestedString: someVal
+  nestedInt: 123
+  nestedBool : true

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.bicep
@@ -89,3 +89,32 @@ var testJsonNestedString2_1 = testJsonObject2_1.nestedString
 var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object.nestedString')
 
 var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')
+
+var testYaml = loadYamlContent('./Assets/test.yaml.txt')
+var testYamlString = testYaml.string
+var testYamlInt = testYaml.int
+var testYamlBool = testYaml.bool
+var testYamlArrayInt = testYaml.arrayInt
+var testYamlArrayIntVal = testYaml.arrayInt[0]
+var testYamlArrayString = testYaml.arrayString
+var testYamlArrayStringVal = testYaml.arrayString[0]
+var testYamlArrayBool = testYaml.arrayBool
+var testYamlArrayBoolVal = testYaml.arrayBool[0]
+var testYamlObject = testYaml.object
+var testYamlObjectNestedString = testYaml.object.nestedString
+var testYamlObjectNestedInt = testYaml.object.nestedInt
+var testYamlObjectNestedBool = testYaml.object.nestedBool
+
+output testYamlString string = testYamlString
+output testYamlInt int = testYamlInt
+output testYamlBool bool = testYamlBool
+output testYamlArrayInt array = testYamlArrayInt
+output testYamlArrayIntVal int = testYamlArrayIntVal
+output testYamlArrayString array = testYamlArrayString
+output testYamlArrayStringVal string = testYamlArrayStringVal
+output testYamlArrayBool array = testYamlArrayBool
+output testYamlArrayBoolVal bool = testYamlArrayBoolVal
+output testYamlObject object = testYamlObject
+output testYamlObjectNestedString string = testYamlObjectNestedString
+output testYamlObjectNestedInt int = testYamlObjectNestedInt
+output testYamlObjectNestedBool bool = testYamlObjectNestedBool

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.diagnostics.bicep
@@ -136,3 +136,32 @@ var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object
 var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')
 //@[4:25) [no-unused-vars (Warning)] Variable "testJsonTokensAsArray" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |testJsonTokensAsArray|
 
+var testYaml = loadYamlContent('./Assets/test.yaml.txt')
+var testYamlString = testYaml.string
+var testYamlInt = testYaml.int
+var testYamlBool = testYaml.bool
+var testYamlArrayInt = testYaml.arrayInt
+var testYamlArrayIntVal = testYaml.arrayInt[0]
+var testYamlArrayString = testYaml.arrayString
+var testYamlArrayStringVal = testYaml.arrayString[0]
+var testYamlArrayBool = testYaml.arrayBool
+var testYamlArrayBoolVal = testYaml.arrayBool[0]
+var testYamlObject = testYaml.object
+var testYamlObjectNestedString = testYaml.object.nestedString
+var testYamlObjectNestedInt = testYaml.object.nestedInt
+var testYamlObjectNestedBool = testYaml.object.nestedBool
+
+output testYamlString string = testYamlString
+output testYamlInt int = testYamlInt
+output testYamlBool bool = testYamlBool
+output testYamlArrayInt array = testYamlArrayInt
+output testYamlArrayIntVal int = testYamlArrayIntVal
+output testYamlArrayString array = testYamlArrayString
+output testYamlArrayStringVal string = testYamlArrayStringVal
+output testYamlArrayBool array = testYamlArrayBool
+output testYamlArrayBoolVal bool = testYamlArrayBoolVal
+output testYamlObject object = testYamlObject
+output testYamlObjectNestedString string = testYamlObjectNestedString
+output testYamlObjectNestedInt int = testYamlObjectNestedInt
+output testYamlObjectNestedBool bool = testYamlObjectNestedBool
+

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.formatted.bicep
@@ -88,3 +88,32 @@ var testJsonNestedString2_1 = testJsonObject2_1.nestedString
 var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object.nestedString')
 
 var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')
+
+var testYaml = loadYamlContent('./Assets/test.yaml.txt')
+var testYamlString = testYaml.string
+var testYamlInt = testYaml.int
+var testYamlBool = testYaml.bool
+var testYamlArrayInt = testYaml.arrayInt
+var testYamlArrayIntVal = testYaml.arrayInt[0]
+var testYamlArrayString = testYaml.arrayString
+var testYamlArrayStringVal = testYaml.arrayString[0]
+var testYamlArrayBool = testYaml.arrayBool
+var testYamlArrayBoolVal = testYaml.arrayBool[0]
+var testYamlObject = testYaml.object
+var testYamlObjectNestedString = testYaml.object.nestedString
+var testYamlObjectNestedInt = testYaml.object.nestedInt
+var testYamlObjectNestedBool = testYaml.object.nestedBool
+
+output testYamlString string = testYamlString
+output testYamlInt int = testYamlInt
+output testYamlBool bool = testYamlBool
+output testYamlArrayInt array = testYamlArrayInt
+output testYamlArrayIntVal int = testYamlArrayIntVal
+output testYamlArrayString array = testYamlArrayString
+output testYamlArrayStringVal string = testYamlArrayStringVal
+output testYamlArrayBool array = testYamlArrayBool
+output testYamlArrayBoolVal bool = testYamlArrayBoolVal
+output testYamlObject object = testYamlObject
+output testYamlObjectNestedString string = testYamlObjectNestedString
+output testYamlObjectNestedInt int = testYamlObjectNestedInt
+output testYamlObjectNestedBool bool = testYamlObjectNestedBool

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.ir.bicep
@@ -1,5 +1,5 @@
 var loadedText1 = loadTextContent('Assets/TextFile.CRLF.txt')
-//@[00:3790) ProgramExpression
+//@[00:5162) ProgramExpression
 //@[00:0000) | └─ObjectExpression [UNPARENTED]
 //@[00:0000) |   ├─ObjectPropertyExpression [UNPARENTED]
 //@[00:0000) |   | ├─StringLiteralExpression { Value = string } [UNPARENTED]
@@ -29,6 +29,43 @@ var loadedText1 = loadTextContent('Assets/TextFile.CRLF.txt')
 //@[00:0000) | └─ArrayExpression [UNPARENTED]
 //@[00:0000) |   ├─StringLiteralExpression { Value = pizza } [UNPARENTED]
 //@[00:0000) |   └─StringLiteralExpression { Value = salad } [UNPARENTED]
+//@[00:0000) | └─ObjectExpression [UNPARENTED]
+//@[00:0000) |   ├─ObjectPropertyExpression [UNPARENTED]
+//@[00:0000) |   | ├─StringLiteralExpression { Value = string } [UNPARENTED]
+//@[00:0000) |   | └─StringLiteralExpression { Value = someVal } [UNPARENTED]
+//@[00:0000) |   ├─ObjectPropertyExpression [UNPARENTED]
+//@[00:0000) |   | ├─StringLiteralExpression { Value = int } [UNPARENTED]
+//@[00:0000) |   | └─IntegerLiteralExpression { Value = 123 } [UNPARENTED]
+//@[00:0000) |   ├─ObjectPropertyExpression [UNPARENTED]
+//@[00:0000) |   | ├─StringLiteralExpression { Value = bool } [UNPARENTED]
+//@[00:0000) |   | └─BooleanLiteralExpression { Value = True } [UNPARENTED]
+//@[00:0000) |   ├─ObjectPropertyExpression [UNPARENTED]
+//@[00:0000) |   | ├─StringLiteralExpression { Value = arrayInt } [UNPARENTED]
+//@[00:0000) |   | └─ArrayExpression [UNPARENTED]
+//@[00:0000) |   |   ├─IntegerLiteralExpression { Value = 1 } [UNPARENTED]
+//@[00:0000) |   |   └─IntegerLiteralExpression { Value = 2 } [UNPARENTED]
+//@[00:0000) |   ├─ObjectPropertyExpression [UNPARENTED]
+//@[00:0000) |   | ├─StringLiteralExpression { Value = arrayString } [UNPARENTED]
+//@[00:0000) |   | └─ArrayExpression [UNPARENTED]
+//@[00:0000) |   |   ├─StringLiteralExpression { Value = someVal } [UNPARENTED]
+//@[00:0000) |   |   └─StringLiteralExpression { Value = someVal2 } [UNPARENTED]
+//@[00:0000) |   ├─ObjectPropertyExpression [UNPARENTED]
+//@[00:0000) |   | ├─StringLiteralExpression { Value = arrayBool } [UNPARENTED]
+//@[00:0000) |   | └─ArrayExpression [UNPARENTED]
+//@[00:0000) |   |   └─BooleanLiteralExpression { Value = True } [UNPARENTED]
+//@[00:0000) |   |   └─BooleanLiteralExpression { Value = True } [UNPARENTED]
+//@[00:0000) |   └─ObjectPropertyExpression [UNPARENTED]
+//@[00:0000) |     ├─StringLiteralExpression { Value = object } [UNPARENTED]
+//@[00:0000) |     └─ObjectExpression [UNPARENTED]
+//@[00:0000) |       ├─ObjectPropertyExpression [UNPARENTED]
+//@[00:0000) |       | ├─StringLiteralExpression { Value = nestedString } [UNPARENTED]
+//@[00:0000) |       | └─StringLiteralExpression { Value = someVal } [UNPARENTED]
+//@[00:0000) |       ├─ObjectPropertyExpression [UNPARENTED]
+//@[00:0000) |       | ├─StringLiteralExpression { Value = nestedInt } [UNPARENTED]
+//@[00:0000) |       | └─IntegerLiteralExpression { Value = 123 } [UNPARENTED]
+//@[00:0000) |       └─ObjectPropertyExpression [UNPARENTED]
+//@[00:0000) |         ├─StringLiteralExpression { Value = nestedBool } [UNPARENTED]
+//@[00:0000) |         └─BooleanLiteralExpression { Value = True } [UNPARENTED]
 //@[00:0061) ├─DeclaredVariableExpression { Name = loadedText1 }
 //@[18:0061) | └─StringLiteralExpression { Value = Lorem ipsum dolor sit amet, consectetur adipiscing elit.\r\n\tProin varius in nunc et laoreet.\r\n  Nam pulvinar ipsum sed lectus porttitor, at porttitor ipsum faucibus.\r\n  \tAliquam euismod, odio tincidunt convallis pulvinar, felis sem porttitor turpis, a condimentum dui erat nec tellus.\r\n  Duis elementum cursus est, congue efficitur risus.\r\n\tMauris sit amet.\r\nExcepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n }
 var loadedText2 = sys.loadTextContent('Assets/TextFile.LF.txt')
@@ -182,20 +219,20 @@ module module1 'modulea.bicep' = {
 }
 
 module module2 'modulea.bicep' = {
-//@[00:0119) └─DeclaredModuleExpression
-//@[33:0119)   ├─ObjectExpression
+//@[00:0119) ├─DeclaredModuleExpression
+//@[33:0119) | ├─ObjectExpression
   name: 'module2'
-//@[02:0017)   | └─ObjectPropertyExpression
-//@[02:0006)   |   ├─StringLiteralExpression { Value = name }
-//@[08:0017)   |   └─StringLiteralExpression { Value = module2 }
+//@[02:0017) | | └─ObjectPropertyExpression
+//@[02:0006) | |   ├─StringLiteralExpression { Value = name }
+//@[08:0017) | |   └─StringLiteralExpression { Value = module2 }
   params: {
-//@[10:0061)   └─ObjectExpression
+//@[10:0061) | └─ObjectExpression
     text: loadFileAsBase64('Assets/binary')
 //@[10:0043) ├─DeclaredVariableExpression { Name = $fxv#14 }
 //@[10:0043) | └─StringLiteralExpression { Value = g8fCjQHuFUfnHlTUHxe3qmjeM3HlYSToV7qTGrcJ6vgFNjvgpmxnexFbzjJV/Ejx8jXKa8L32YUn1f/HUnPY6u5c1SaGaP8OiVyRK4ef52hOtc3Yd29c9ubDsLohwLlmuiQDCvVduNMejR6eZy50ti3eYaLu3e04IKC7kTFO0Ph/vSIhlfkS6lUB9e7EJuHAa+3yJFn0uIVFs/BF67fNV9zwx92XyhFL8tmv3IZNd1+0cAby99+zif6iBPXcJ5XTUUz4UHaPmZLPT75hd4iGZzOk/I+FAsUTxRDra76D+sSXay7qBv5TyVLlhs7kqSVAecki6vQG0Siku64tl3PKKEy9JV1lHItgg/IFDYNd8/DKMUpEi90wunW/CfTpQcctzHzZFjl5euswaXgTDvVt2KRHPpi3likE8b1GuyKFVfKNT47VFGSabuUZlhDzbzx7qECnIpA1M7kH+TUHhGTe3ezmmPq+EO6jybYNMpMs+7gcfYAEtzE4gfpubKHLQI8ZYFKFxPCo0ypOwh4Z1nStJkcrNX2UlSDFfPb+LlCaGRxRKPN9md+2sr4x6qm0TptmI9o8wJF7FvqJUS2obFz2KhnfdKg7seuknpisasENchzEO2hoMtpCf5Lt3ZwsLCnFrllFaNmV2BWfA0k74f5MykjIioppM8ajdzORDtjTv/WcNyxdVlTV6nr2Oe43WFKZT0DFMDGHVgTZRBxVH5JtfT1akurR+IyvTegR6kSMHXSWlE1iEoPK8gdNpFLHdAJ8VwPnMGRC8CoCGzDeAakmwiHuecPOzcg9cOQe2Rlo68kJSr6q2hEcTmm9kPj7vfAeocqlosDd2Ci7xcBAJNb/rC4IVllhZPyqt2C8L1VbN5wZfBNgwpA73oOX0kxIKoCqH+Ni167WvC1ZwTqlVAWeAa1RiSplisinKBwDXahu2qDhVJyOt/RwV8Y+W3ynFGXYOW9BDwXVwKUm2zrKl6j0Y1AUTH5HArfCwwThXW2ZFslbr/fM9nJPAbbxpDY2FQBAlt8ST3PyLrFBfXlsV0JqVhidnw94NAbTiPqck15pTGbncg8VunYUAMw/JAOLf2SIJ8cA75IdJMp0UJXoMcOfVKkVdgMbGi7BHtJ3ZFwIajbNdWoNQV0k/LlwwmqGYGkh71wBX4WEdW6MqvvT8Mt/xyA6xzflqnMzgvQPIe6v29FETR9wxSKG52oCOY/DtPXEo+DgZvQwQn3F4BwX+GZawHbbMjWCIDxoSmph5TfZMzF0EkhEi47Uk93FPgiBQPjKSYMxnJ9Lo9UwZjsxdtk7ONKe1GIxfHdx3no4uuRp8WKqjpz017VBOWubdXPxO8Q8QOv6nT9faVVCMUQApehFlg== }
-//@[04:0043)     └─ObjectPropertyExpression
-//@[04:0008)       ├─StringLiteralExpression { Value = text }
-//@[10:0043)       └─SynthesizedVariableReferenceExpression { Name = $fxv#14 }
+//@[04:0043) |   └─ObjectPropertyExpression
+//@[04:0008) |     ├─StringLiteralExpression { Value = text }
+//@[10:0043) |     └─SynthesizedVariableReferenceExpression { Name = $fxv#14 }
   }
 }
 
@@ -313,4 +350,113 @@ var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.product
 //@[28:0104) ├─DeclaredVariableExpression { Name = $fxv#22 }
 //@[00:0104) ├─DeclaredVariableExpression { Name = testJsonTokensAsArray }
 //@[28:0104) | └─SynthesizedVariableReferenceExpression { Name = $fxv#22 }
+
+var testYaml = loadYamlContent('./Assets/test.yaml.txt')
+//@[15:0056) ├─DeclaredVariableExpression { Name = $fxv#23 }
+//@[00:0056) ├─DeclaredVariableExpression { Name = testYaml }
+//@[15:0056) | └─SynthesizedVariableReferenceExpression { Name = $fxv#23 }
+var testYamlString = testYaml.string
+//@[00:0036) ├─DeclaredVariableExpression { Name = testYamlString }
+//@[21:0036) | └─PropertyAccessExpression { PropertyName = string }
+//@[21:0029) |   └─VariableReferenceExpression { Variable = testYaml }
+var testYamlInt = testYaml.int
+//@[00:0030) ├─DeclaredVariableExpression { Name = testYamlInt }
+//@[18:0030) | └─PropertyAccessExpression { PropertyName = int }
+//@[18:0026) |   └─VariableReferenceExpression { Variable = testYaml }
+var testYamlBool = testYaml.bool
+//@[00:0032) ├─DeclaredVariableExpression { Name = testYamlBool }
+//@[19:0032) | └─PropertyAccessExpression { PropertyName = bool }
+//@[19:0027) |   └─VariableReferenceExpression { Variable = testYaml }
+var testYamlArrayInt = testYaml.arrayInt
+//@[00:0040) ├─DeclaredVariableExpression { Name = testYamlArrayInt }
+//@[23:0040) | └─PropertyAccessExpression { PropertyName = arrayInt }
+//@[23:0031) |   └─VariableReferenceExpression { Variable = testYaml }
+var testYamlArrayIntVal = testYaml.arrayInt[0]
+//@[00:0046) ├─DeclaredVariableExpression { Name = testYamlArrayIntVal }
+//@[26:0046) | └─AccessChainExpression
+//@[26:0043) |   ├─PropertyAccessExpression { PropertyName = arrayInt }
+//@[26:0034) |   | └─VariableReferenceExpression { Variable = testYaml }
+//@[44:0045) |   └─IntegerLiteralExpression { Value = 0 }
+var testYamlArrayString = testYaml.arrayString
+//@[00:0046) ├─DeclaredVariableExpression { Name = testYamlArrayString }
+//@[26:0046) | └─PropertyAccessExpression { PropertyName = arrayString }
+//@[26:0034) |   └─VariableReferenceExpression { Variable = testYaml }
+var testYamlArrayStringVal = testYaml.arrayString[0]
+//@[00:0052) ├─DeclaredVariableExpression { Name = testYamlArrayStringVal }
+//@[29:0052) | └─AccessChainExpression
+//@[29:0049) |   ├─PropertyAccessExpression { PropertyName = arrayString }
+//@[29:0037) |   | └─VariableReferenceExpression { Variable = testYaml }
+//@[50:0051) |   └─IntegerLiteralExpression { Value = 0 }
+var testYamlArrayBool = testYaml.arrayBool
+//@[00:0042) ├─DeclaredVariableExpression { Name = testYamlArrayBool }
+//@[24:0042) | └─PropertyAccessExpression { PropertyName = arrayBool }
+//@[24:0032) |   └─VariableReferenceExpression { Variable = testYaml }
+var testYamlArrayBoolVal = testYaml.arrayBool[0]
+//@[00:0048) ├─DeclaredVariableExpression { Name = testYamlArrayBoolVal }
+//@[27:0048) | └─AccessChainExpression
+//@[27:0045) |   ├─PropertyAccessExpression { PropertyName = arrayBool }
+//@[27:0035) |   | └─VariableReferenceExpression { Variable = testYaml }
+//@[46:0047) |   └─IntegerLiteralExpression { Value = 0 }
+var testYamlObject = testYaml.object
+//@[00:0036) ├─DeclaredVariableExpression { Name = testYamlObject }
+//@[21:0036) | └─PropertyAccessExpression { PropertyName = object }
+//@[21:0029) |   └─VariableReferenceExpression { Variable = testYaml }
+var testYamlObjectNestedString = testYaml.object.nestedString
+//@[00:0061) ├─DeclaredVariableExpression { Name = testYamlObjectNestedString }
+//@[33:0061) | └─AccessChainExpression
+//@[33:0048) |   ├─PropertyAccessExpression { PropertyName = object }
+//@[33:0041) |   | └─VariableReferenceExpression { Variable = testYaml }
+//@[49:0061) |   └─StringLiteralExpression { Value = nestedString }
+var testYamlObjectNestedInt = testYaml.object.nestedInt
+//@[00:0055) ├─DeclaredVariableExpression { Name = testYamlObjectNestedInt }
+//@[30:0055) | └─AccessChainExpression
+//@[30:0045) |   ├─PropertyAccessExpression { PropertyName = object }
+//@[30:0038) |   | └─VariableReferenceExpression { Variable = testYaml }
+//@[46:0055) |   └─StringLiteralExpression { Value = nestedInt }
+var testYamlObjectNestedBool = testYaml.object.nestedBool
+//@[00:0057) ├─DeclaredVariableExpression { Name = testYamlObjectNestedBool }
+//@[31:0057) | └─AccessChainExpression
+//@[31:0046) |   ├─PropertyAccessExpression { PropertyName = object }
+//@[31:0039) |   | └─VariableReferenceExpression { Variable = testYaml }
+//@[47:0057) |   └─StringLiteralExpression { Value = nestedBool }
+
+output testYamlString string = testYamlString
+//@[00:0045) ├─DeclaredOutputExpression { Name = testYamlString }
+//@[31:0045) | └─VariableReferenceExpression { Variable = testYamlString }
+output testYamlInt int = testYamlInt
+//@[00:0036) ├─DeclaredOutputExpression { Name = testYamlInt }
+//@[25:0036) | └─VariableReferenceExpression { Variable = testYamlInt }
+output testYamlBool bool = testYamlBool
+//@[00:0039) ├─DeclaredOutputExpression { Name = testYamlBool }
+//@[27:0039) | └─VariableReferenceExpression { Variable = testYamlBool }
+output testYamlArrayInt array = testYamlArrayInt
+//@[00:0048) ├─DeclaredOutputExpression { Name = testYamlArrayInt }
+//@[32:0048) | └─VariableReferenceExpression { Variable = testYamlArrayInt }
+output testYamlArrayIntVal int = testYamlArrayIntVal
+//@[00:0052) ├─DeclaredOutputExpression { Name = testYamlArrayIntVal }
+//@[33:0052) | └─VariableReferenceExpression { Variable = testYamlArrayIntVal }
+output testYamlArrayString array = testYamlArrayString
+//@[00:0054) ├─DeclaredOutputExpression { Name = testYamlArrayString }
+//@[35:0054) | └─VariableReferenceExpression { Variable = testYamlArrayString }
+output testYamlArrayStringVal string = testYamlArrayStringVal
+//@[00:0061) ├─DeclaredOutputExpression { Name = testYamlArrayStringVal }
+//@[39:0061) | └─VariableReferenceExpression { Variable = testYamlArrayStringVal }
+output testYamlArrayBool array = testYamlArrayBool
+//@[00:0050) ├─DeclaredOutputExpression { Name = testYamlArrayBool }
+//@[33:0050) | └─VariableReferenceExpression { Variable = testYamlArrayBool }
+output testYamlArrayBoolVal bool = testYamlArrayBoolVal
+//@[00:0055) ├─DeclaredOutputExpression { Name = testYamlArrayBoolVal }
+//@[35:0055) | └─VariableReferenceExpression { Variable = testYamlArrayBoolVal }
+output testYamlObject object = testYamlObject
+//@[00:0045) ├─DeclaredOutputExpression { Name = testYamlObject }
+//@[31:0045) | └─VariableReferenceExpression { Variable = testYamlObject }
+output testYamlObjectNestedString string = testYamlObjectNestedString
+//@[00:0069) ├─DeclaredOutputExpression { Name = testYamlObjectNestedString }
+//@[43:0069) | └─VariableReferenceExpression { Variable = testYamlObjectNestedString }
+output testYamlObjectNestedInt int = testYamlObjectNestedInt
+//@[00:0060) ├─DeclaredOutputExpression { Name = testYamlObjectNestedInt }
+//@[37:0060) | └─VariableReferenceExpression { Variable = testYamlObjectNestedInt }
+output testYamlObjectNestedBool bool = testYamlObjectNestedBool
+//@[00:0063) └─DeclaredOutputExpression { Name = testYamlObjectNestedBool }
+//@[39:0063)   └─VariableReferenceExpression { Variable = testYamlObjectNestedBool }
 

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12490339809850339782"
+      "templateHash": "11669324362880351006"
     }
   },
   "variables": {
@@ -40,6 +40,28 @@
       "pizza",
       "salad"
     ],
+    "$fxv#23": {
+      "string": "someVal",
+      "int": 123,
+      "bool": true,
+      "arrayInt": [
+        1,
+        2
+      ],
+      "arrayString": [
+        "someVal",
+        "someVal2"
+      ],
+      "arrayBool": [
+        true,
+        true
+      ],
+      "object": {
+        "nestedString": "someVal",
+        "nestedInt": 123,
+        "nestedBool": true
+      }
+    },
     "$fxv#3": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Donec laoreet sem tortor, ut dignissim ipsum ornare vel.\n  Duis ac ipsum turpis.\n\tMaecenas at condimentum dui.\n Suspendisse aliquet efficitur iaculis.\nIn hac habitasse platea dictumst.\nEtiam consectetur ut libero ac lobortis.\n\tNullam vitae auctor massa.\nFusce tincidunt urna purus, sit amet.\n",
     "$fxv#4": "g8fCjQHuFUfnHlTUHxe3qmjeM3HlYSToV7qTGrcJ6vgFNjvgpmxnexFbzjJV/Ejx8jXKa8L32YUn1f/HUnPY6u5c1SaGaP8OiVyRK4ef52hOtc3Yd29c9ubDsLohwLlmuiQDCvVduNMejR6eZy50ti3eYaLu3e04IKC7kTFO0Ph/vSIhlfkS6lUB9e7EJuHAa+3yJFn0uIVFs/BF67fNV9zwx92XyhFL8tmv3IZNd1+0cAby99+zif6iBPXcJ5XTUUz4UHaPmZLPT75hd4iGZzOk/I+FAsUTxRDra76D+sSXay7qBv5TyVLlhs7kqSVAecki6vQG0Siku64tl3PKKEy9JV1lHItgg/IFDYNd8/DKMUpEi90wunW/CfTpQcctzHzZFjl5euswaXgTDvVt2KRHPpi3likE8b1GuyKFVfKNT47VFGSabuUZlhDzbzx7qECnIpA1M7kH+TUHhGTe3ezmmPq+EO6jybYNMpMs+7gcfYAEtzE4gfpubKHLQI8ZYFKFxPCo0ypOwh4Z1nStJkcrNX2UlSDFfPb+LlCaGRxRKPN9md+2sr4x6qm0TptmI9o8wJF7FvqJUS2obFz2KhnfdKg7seuknpisasENchzEO2hoMtpCf5Lt3ZwsLCnFrllFaNmV2BWfA0k74f5MykjIioppM8ajdzORDtjTv/WcNyxdVlTV6nr2Oe43WFKZT0DFMDGHVgTZRBxVH5JtfT1akurR+IyvTegR6kSMHXSWlE1iEoPK8gdNpFLHdAJ8VwPnMGRC8CoCGzDeAakmwiHuecPOzcg9cOQe2Rlo68kJSr6q2hEcTmm9kPj7vfAeocqlosDd2Ci7xcBAJNb/rC4IVllhZPyqt2C8L1VbN5wZfBNgwpA73oOX0kxIKoCqH+Ni167WvC1ZwTqlVAWeAa1RiSplisinKBwDXahu2qDhVJyOt/RwV8Y+W3ynFGXYOW9BDwXVwKUm2zrKl6j0Y1AUTH5HArfCwwThXW2ZFslbr/fM9nJPAbbxpDY2FQBAlt8ST3PyLrFBfXlsV0JqVhidnw94NAbTiPqck15pTGbncg8VunYUAMw/JAOLf2SIJ8cA75IdJMp0UJXoMcOfVKkVdgMbGi7BHtJ3ZFwIajbNdWoNQV0k/LlwwmqGYGkh71wBX4WEdW6MqvvT8Mt/xyA6xzflqnMzgvQPIe6v29FETR9wxSKG52oCOY/DtPXEo+DgZvQwQn3F4BwX+GZawHbbMjWCIDxoSmph5TfZMzF0EkhEi47Uk93FPgiBQPjKSYMxnJ9Lo9UwZjsxdtk7ONKe1GIxfHdx3no4uuRp8WKqjpz017VBOWubdXPxO8Q8QOv6nT9faVVCMUQApehFlg==",
     "$fxv#5": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Donec laoreet sem tortor, ut dignissim ipsum ornare vel.\n  Duis ac ipsum turpis.\n\tMaecenas at condimentum dui.\n Suspendisse aliquet efficitur iaculis.\nIn hac habitasse platea dictumst.\nEtiam consectetur ut libero ac lobortis.\n\tNullam vitae auctor massa.\nFusce tincidunt urna purus, sit amet.\n",
@@ -111,7 +133,21 @@
     "testJsonNestedString2": "[variables('testJson').object.nestedString]",
     "testJsonNestedString2_1": "[variables('testJsonObject2_1').nestedString]",
     "testJsonNestedString2_2": "[variables('$fxv#21')]",
-    "testJsonTokensAsArray": "[variables('$fxv#22')]"
+    "testJsonTokensAsArray": "[variables('$fxv#22')]",
+    "testYaml": "[variables('$fxv#23')]",
+    "testYamlString": "[variables('testYaml').string]",
+    "testYamlInt": "[variables('testYaml').int]",
+    "testYamlBool": "[variables('testYaml').bool]",
+    "testYamlArrayInt": "[variables('testYaml').arrayInt]",
+    "testYamlArrayIntVal": "[variables('testYaml').arrayInt[0]]",
+    "testYamlArrayString": "[variables('testYaml').arrayString]",
+    "testYamlArrayStringVal": "[variables('testYaml').arrayString[0]]",
+    "testYamlArrayBool": "[variables('testYaml').arrayBool]",
+    "testYamlArrayBoolVal": "[variables('testYaml').arrayBool[0]]",
+    "testYamlObject": "[variables('testYaml').object]",
+    "testYamlObjectNestedString": "[variables('testYaml').object.nestedString]",
+    "testYamlObjectNestedInt": "[variables('testYaml').object.nestedInt]",
+    "testYamlObjectNestedBool": "[variables('testYaml').object.nestedBool]"
   },
   "resources": [
     {
@@ -180,5 +216,59 @@
         }
       }
     }
-  ]
+  ],
+  "outputs": {
+    "testYamlString": {
+      "type": "string",
+      "value": "[variables('testYamlString')]"
+    },
+    "testYamlInt": {
+      "type": "int",
+      "value": "[variables('testYamlInt')]"
+    },
+    "testYamlBool": {
+      "type": "bool",
+      "value": "[variables('testYamlBool')]"
+    },
+    "testYamlArrayInt": {
+      "type": "array",
+      "value": "[variables('testYamlArrayInt')]"
+    },
+    "testYamlArrayIntVal": {
+      "type": "int",
+      "value": "[variables('testYamlArrayIntVal')]"
+    },
+    "testYamlArrayString": {
+      "type": "array",
+      "value": "[variables('testYamlArrayString')]"
+    },
+    "testYamlArrayStringVal": {
+      "type": "string",
+      "value": "[variables('testYamlArrayStringVal')]"
+    },
+    "testYamlArrayBool": {
+      "type": "array",
+      "value": "[variables('testYamlArrayBool')]"
+    },
+    "testYamlArrayBoolVal": {
+      "type": "bool",
+      "value": "[variables('testYamlArrayBoolVal')]"
+    },
+    "testYamlObject": {
+      "type": "object",
+      "value": "[variables('testYamlObject')]"
+    },
+    "testYamlObjectNestedString": {
+      "type": "string",
+      "value": "[variables('testYamlObjectNestedString')]"
+    },
+    "testYamlObjectNestedInt": {
+      "type": "int",
+      "value": "[variables('testYamlObjectNestedInt')]"
+    },
+    "testYamlObjectNestedBool": {
+      "type": "bool",
+      "value": "[variables('testYamlObjectNestedBool')]"
+    }
+  }
 }

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.sourcemap.bicep
@@ -235,5 +235,100 @@ var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object
 //@    "testJsonNestedString2_2": "[variables('$fxv#21')]",
 
 var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')
-//@    "testJsonTokensAsArray": "[variables('$fxv#22')]"
+//@    "testJsonTokensAsArray": "[variables('$fxv#22')]",
+
+var testYaml = loadYamlContent('./Assets/test.yaml.txt')
+//@    "testYaml": "[variables('$fxv#23')]",
+var testYamlString = testYaml.string
+//@    "testYamlString": "[variables('testYaml').string]",
+var testYamlInt = testYaml.int
+//@    "testYamlInt": "[variables('testYaml').int]",
+var testYamlBool = testYaml.bool
+//@    "testYamlBool": "[variables('testYaml').bool]",
+var testYamlArrayInt = testYaml.arrayInt
+//@    "testYamlArrayInt": "[variables('testYaml').arrayInt]",
+var testYamlArrayIntVal = testYaml.arrayInt[0]
+//@    "testYamlArrayIntVal": "[variables('testYaml').arrayInt[0]]",
+var testYamlArrayString = testYaml.arrayString
+//@    "testYamlArrayString": "[variables('testYaml').arrayString]",
+var testYamlArrayStringVal = testYaml.arrayString[0]
+//@    "testYamlArrayStringVal": "[variables('testYaml').arrayString[0]]",
+var testYamlArrayBool = testYaml.arrayBool
+//@    "testYamlArrayBool": "[variables('testYaml').arrayBool]",
+var testYamlArrayBoolVal = testYaml.arrayBool[0]
+//@    "testYamlArrayBoolVal": "[variables('testYaml').arrayBool[0]]",
+var testYamlObject = testYaml.object
+//@    "testYamlObject": "[variables('testYaml').object]",
+var testYamlObjectNestedString = testYaml.object.nestedString
+//@    "testYamlObjectNestedString": "[variables('testYaml').object.nestedString]",
+var testYamlObjectNestedInt = testYaml.object.nestedInt
+//@    "testYamlObjectNestedInt": "[variables('testYaml').object.nestedInt]",
+var testYamlObjectNestedBool = testYaml.object.nestedBool
+//@    "testYamlObjectNestedBool": "[variables('testYaml').object.nestedBool]"
+
+output testYamlString string = testYamlString
+//@    "testYamlString": {
+//@      "type": "string",
+//@      "value": "[variables('testYamlString')]"
+//@    },
+output testYamlInt int = testYamlInt
+//@    "testYamlInt": {
+//@      "type": "int",
+//@      "value": "[variables('testYamlInt')]"
+//@    },
+output testYamlBool bool = testYamlBool
+//@    "testYamlBool": {
+//@      "type": "bool",
+//@      "value": "[variables('testYamlBool')]"
+//@    },
+output testYamlArrayInt array = testYamlArrayInt
+//@    "testYamlArrayInt": {
+//@      "type": "array",
+//@      "value": "[variables('testYamlArrayInt')]"
+//@    },
+output testYamlArrayIntVal int = testYamlArrayIntVal
+//@    "testYamlArrayIntVal": {
+//@      "type": "int",
+//@      "value": "[variables('testYamlArrayIntVal')]"
+//@    },
+output testYamlArrayString array = testYamlArrayString
+//@    "testYamlArrayString": {
+//@      "type": "array",
+//@      "value": "[variables('testYamlArrayString')]"
+//@    },
+output testYamlArrayStringVal string = testYamlArrayStringVal
+//@    "testYamlArrayStringVal": {
+//@      "type": "string",
+//@      "value": "[variables('testYamlArrayStringVal')]"
+//@    },
+output testYamlArrayBool array = testYamlArrayBool
+//@    "testYamlArrayBool": {
+//@      "type": "array",
+//@      "value": "[variables('testYamlArrayBool')]"
+//@    },
+output testYamlArrayBoolVal bool = testYamlArrayBoolVal
+//@    "testYamlArrayBoolVal": {
+//@      "type": "bool",
+//@      "value": "[variables('testYamlArrayBoolVal')]"
+//@    },
+output testYamlObject object = testYamlObject
+//@    "testYamlObject": {
+//@      "type": "object",
+//@      "value": "[variables('testYamlObject')]"
+//@    },
+output testYamlObjectNestedString string = testYamlObjectNestedString
+//@    "testYamlObjectNestedString": {
+//@      "type": "string",
+//@      "value": "[variables('testYamlObjectNestedString')]"
+//@    },
+output testYamlObjectNestedInt int = testYamlObjectNestedInt
+//@    "testYamlObjectNestedInt": {
+//@      "type": "int",
+//@      "value": "[variables('testYamlObjectNestedInt')]"
+//@    },
+output testYamlObjectNestedBool bool = testYamlObjectNestedBool
+//@    "testYamlObjectNestedBool": {
+//@      "type": "bool",
+//@      "value": "[variables('testYamlObjectNestedBool')]"
+//@    }
 

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10973414352775753606"
+      "templateHash": "1782788314830618129"
     }
   },
   "variables": {
@@ -42,6 +42,28 @@
       "pizza",
       "salad"
     ],
+    "$fxv#23": {
+      "string": "someVal",
+      "int": 123,
+      "bool": true,
+      "arrayInt": [
+        1,
+        2
+      ],
+      "arrayString": [
+        "someVal",
+        "someVal2"
+      ],
+      "arrayBool": [
+        true,
+        true
+      ],
+      "object": {
+        "nestedString": "someVal",
+        "nestedInt": 123,
+        "nestedBool": true
+      }
+    },
     "$fxv#3": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Donec laoreet sem tortor, ut dignissim ipsum ornare vel.\n  Duis ac ipsum turpis.\n\tMaecenas at condimentum dui.\n Suspendisse aliquet efficitur iaculis.\nIn hac habitasse platea dictumst.\nEtiam consectetur ut libero ac lobortis.\n\tNullam vitae auctor massa.\nFusce tincidunt urna purus, sit amet.\n",
     "$fxv#4": "g8fCjQHuFUfnHlTUHxe3qmjeM3HlYSToV7qTGrcJ6vgFNjvgpmxnexFbzjJV/Ejx8jXKa8L32YUn1f/HUnPY6u5c1SaGaP8OiVyRK4ef52hOtc3Yd29c9ubDsLohwLlmuiQDCvVduNMejR6eZy50ti3eYaLu3e04IKC7kTFO0Ph/vSIhlfkS6lUB9e7EJuHAa+3yJFn0uIVFs/BF67fNV9zwx92XyhFL8tmv3IZNd1+0cAby99+zif6iBPXcJ5XTUUz4UHaPmZLPT75hd4iGZzOk/I+FAsUTxRDra76D+sSXay7qBv5TyVLlhs7kqSVAecki6vQG0Siku64tl3PKKEy9JV1lHItgg/IFDYNd8/DKMUpEi90wunW/CfTpQcctzHzZFjl5euswaXgTDvVt2KRHPpi3likE8b1GuyKFVfKNT47VFGSabuUZlhDzbzx7qECnIpA1M7kH+TUHhGTe3ezmmPq+EO6jybYNMpMs+7gcfYAEtzE4gfpubKHLQI8ZYFKFxPCo0ypOwh4Z1nStJkcrNX2UlSDFfPb+LlCaGRxRKPN9md+2sr4x6qm0TptmI9o8wJF7FvqJUS2obFz2KhnfdKg7seuknpisasENchzEO2hoMtpCf5Lt3ZwsLCnFrllFaNmV2BWfA0k74f5MykjIioppM8ajdzORDtjTv/WcNyxdVlTV6nr2Oe43WFKZT0DFMDGHVgTZRBxVH5JtfT1akurR+IyvTegR6kSMHXSWlE1iEoPK8gdNpFLHdAJ8VwPnMGRC8CoCGzDeAakmwiHuecPOzcg9cOQe2Rlo68kJSr6q2hEcTmm9kPj7vfAeocqlosDd2Ci7xcBAJNb/rC4IVllhZPyqt2C8L1VbN5wZfBNgwpA73oOX0kxIKoCqH+Ni167WvC1ZwTqlVAWeAa1RiSplisinKBwDXahu2qDhVJyOt/RwV8Y+W3ynFGXYOW9BDwXVwKUm2zrKl6j0Y1AUTH5HArfCwwThXW2ZFslbr/fM9nJPAbbxpDY2FQBAlt8ST3PyLrFBfXlsV0JqVhidnw94NAbTiPqck15pTGbncg8VunYUAMw/JAOLf2SIJ8cA75IdJMp0UJXoMcOfVKkVdgMbGi7BHtJ3ZFwIajbNdWoNQV0k/LlwwmqGYGkh71wBX4WEdW6MqvvT8Mt/xyA6xzflqnMzgvQPIe6v29FETR9wxSKG52oCOY/DtPXEo+DgZvQwQn3F4BwX+GZawHbbMjWCIDxoSmph5TfZMzF0EkhEi47Uk93FPgiBQPjKSYMxnJ9Lo9UwZjsxdtk7ONKe1GIxfHdx3no4uuRp8WKqjpz017VBOWubdXPxO8Q8QOv6nT9faVVCMUQApehFlg==",
     "$fxv#5": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Donec laoreet sem tortor, ut dignissim ipsum ornare vel.\n  Duis ac ipsum turpis.\n\tMaecenas at condimentum dui.\n Suspendisse aliquet efficitur iaculis.\nIn hac habitasse platea dictumst.\nEtiam consectetur ut libero ac lobortis.\n\tNullam vitae auctor massa.\nFusce tincidunt urna purus, sit amet.\n",
@@ -113,7 +135,21 @@
     "testJsonNestedString2": "[variables('testJson').object.nestedString]",
     "testJsonNestedString2_1": "[variables('testJsonObject2_1').nestedString]",
     "testJsonNestedString2_2": "[variables('$fxv#21')]",
-    "testJsonTokensAsArray": "[variables('$fxv#22')]"
+    "testJsonTokensAsArray": "[variables('$fxv#22')]",
+    "testYaml": "[variables('$fxv#23')]",
+    "testYamlString": "[variables('testYaml').string]",
+    "testYamlInt": "[variables('testYaml').int]",
+    "testYamlBool": "[variables('testYaml').bool]",
+    "testYamlArrayInt": "[variables('testYaml').arrayInt]",
+    "testYamlArrayIntVal": "[variables('testYaml').arrayInt[0]]",
+    "testYamlArrayString": "[variables('testYaml').arrayString]",
+    "testYamlArrayStringVal": "[variables('testYaml').arrayString[0]]",
+    "testYamlArrayBool": "[variables('testYaml').arrayBool]",
+    "testYamlArrayBoolVal": "[variables('testYaml').arrayBool[0]]",
+    "testYamlObject": "[variables('testYaml').object]",
+    "testYamlObjectNestedString": "[variables('testYaml').object.nestedString]",
+    "testYamlObjectNestedInt": "[variables('testYaml').object.nestedInt]",
+    "testYamlObjectNestedBool": "[variables('testYaml').object.nestedBool]"
   },
   "resources": {
     "module1": {
@@ -185,6 +221,60 @@
           "resources": {}
         }
       }
+    }
+  },
+  "outputs": {
+    "testYamlString": {
+      "type": "string",
+      "value": "[variables('testYamlString')]"
+    },
+    "testYamlInt": {
+      "type": "int",
+      "value": "[variables('testYamlInt')]"
+    },
+    "testYamlBool": {
+      "type": "bool",
+      "value": "[variables('testYamlBool')]"
+    },
+    "testYamlArrayInt": {
+      "type": "array",
+      "value": "[variables('testYamlArrayInt')]"
+    },
+    "testYamlArrayIntVal": {
+      "type": "int",
+      "value": "[variables('testYamlArrayIntVal')]"
+    },
+    "testYamlArrayString": {
+      "type": "array",
+      "value": "[variables('testYamlArrayString')]"
+    },
+    "testYamlArrayStringVal": {
+      "type": "string",
+      "value": "[variables('testYamlArrayStringVal')]"
+    },
+    "testYamlArrayBool": {
+      "type": "array",
+      "value": "[variables('testYamlArrayBool')]"
+    },
+    "testYamlArrayBoolVal": {
+      "type": "bool",
+      "value": "[variables('testYamlArrayBoolVal')]"
+    },
+    "testYamlObject": {
+      "type": "object",
+      "value": "[variables('testYamlObject')]"
+    },
+    "testYamlObjectNestedString": {
+      "type": "string",
+      "value": "[variables('testYamlObjectNestedString')]"
+    },
+    "testYamlObjectNestedInt": {
+      "type": "int",
+      "value": "[variables('testYamlObjectNestedInt')]"
+    },
+    "testYamlObjectNestedBool": {
+      "type": "bool",
+      "value": "[variables('testYamlObjectNestedBool')]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbols.bicep
@@ -136,3 +136,59 @@ var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object
 var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')
 //@[4:25) Variable testJsonTokensAsArray. Type: ('pizza' | 'salad')[]. Declaration start char: 0, length: 104
 
+var testYaml = loadYamlContent('./Assets/test.yaml.txt')
+//@[4:12) Variable testYaml. Type: object. Declaration start char: 0, length: 56
+var testYamlString = testYaml.string
+//@[4:18) Variable testYamlString. Type: 'someVal'. Declaration start char: 0, length: 36
+var testYamlInt = testYaml.int
+//@[4:15) Variable testYamlInt. Type: int. Declaration start char: 0, length: 30
+var testYamlBool = testYaml.bool
+//@[4:16) Variable testYamlBool. Type: bool. Declaration start char: 0, length: 32
+var testYamlArrayInt = testYaml.arrayInt
+//@[4:20) Variable testYamlArrayInt. Type: int[]. Declaration start char: 0, length: 40
+var testYamlArrayIntVal = testYaml.arrayInt[0]
+//@[4:23) Variable testYamlArrayIntVal. Type: int. Declaration start char: 0, length: 46
+var testYamlArrayString = testYaml.arrayString
+//@[4:23) Variable testYamlArrayString. Type: ('someVal' | 'someVal2')[]. Declaration start char: 0, length: 46
+var testYamlArrayStringVal = testYaml.arrayString[0]
+//@[4:26) Variable testYamlArrayStringVal. Type: 'someVal' | 'someVal2'. Declaration start char: 0, length: 52
+var testYamlArrayBool = testYaml.arrayBool
+//@[4:21) Variable testYamlArrayBool. Type: bool[]. Declaration start char: 0, length: 42
+var testYamlArrayBoolVal = testYaml.arrayBool[0]
+//@[4:24) Variable testYamlArrayBoolVal. Type: bool. Declaration start char: 0, length: 48
+var testYamlObject = testYaml.object
+//@[4:18) Variable testYamlObject. Type: object. Declaration start char: 0, length: 36
+var testYamlObjectNestedString = testYaml.object.nestedString
+//@[4:30) Variable testYamlObjectNestedString. Type: 'someVal'. Declaration start char: 0, length: 61
+var testYamlObjectNestedInt = testYaml.object.nestedInt
+//@[4:27) Variable testYamlObjectNestedInt. Type: int. Declaration start char: 0, length: 55
+var testYamlObjectNestedBool = testYaml.object.nestedBool
+//@[4:28) Variable testYamlObjectNestedBool. Type: bool. Declaration start char: 0, length: 57
+
+output testYamlString string = testYamlString
+//@[7:21) Output testYamlString. Type: string. Declaration start char: 0, length: 45
+output testYamlInt int = testYamlInt
+//@[7:18) Output testYamlInt. Type: int. Declaration start char: 0, length: 36
+output testYamlBool bool = testYamlBool
+//@[7:19) Output testYamlBool. Type: bool. Declaration start char: 0, length: 39
+output testYamlArrayInt array = testYamlArrayInt
+//@[7:23) Output testYamlArrayInt. Type: array. Declaration start char: 0, length: 48
+output testYamlArrayIntVal int = testYamlArrayIntVal
+//@[7:26) Output testYamlArrayIntVal. Type: int. Declaration start char: 0, length: 52
+output testYamlArrayString array = testYamlArrayString
+//@[7:26) Output testYamlArrayString. Type: array. Declaration start char: 0, length: 54
+output testYamlArrayStringVal string = testYamlArrayStringVal
+//@[7:29) Output testYamlArrayStringVal. Type: string. Declaration start char: 0, length: 61
+output testYamlArrayBool array = testYamlArrayBool
+//@[7:24) Output testYamlArrayBool. Type: array. Declaration start char: 0, length: 50
+output testYamlArrayBoolVal bool = testYamlArrayBoolVal
+//@[7:27) Output testYamlArrayBoolVal. Type: bool. Declaration start char: 0, length: 55
+output testYamlObject object = testYamlObject
+//@[7:21) Output testYamlObject. Type: object. Declaration start char: 0, length: 45
+output testYamlObjectNestedString string = testYamlObjectNestedString
+//@[7:33) Output testYamlObjectNestedString. Type: string. Declaration start char: 0, length: 69
+output testYamlObjectNestedInt int = testYamlObjectNestedInt
+//@[7:30) Output testYamlObjectNestedInt. Type: int. Declaration start char: 0, length: 60
+output testYamlObjectNestedBool bool = testYamlObjectNestedBool
+//@[7:31) Output testYamlObjectNestedBool. Type: bool. Declaration start char: 0, length: 63
+

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.syntax.bicep
@@ -1,5 +1,5 @@
 var loadedText1 = loadTextContent('Assets/TextFile.CRLF.txt')
-//@[000:3790) ProgramSyntax
+//@[000:5162) ProgramSyntax
 //@[000:0061) ├─VariableDeclarationSyntax
 //@[000:0003) | ├─Token(Identifier) |var|
 //@[004:0015) | ├─IdentifierSyntax
@@ -1027,6 +1027,401 @@ var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.product
 //@[071:0103) |   | └─StringSyntax
 //@[071:0103) |   |   └─Token(StringComplete) |'.products[?(@.price > 3)].name'|
 //@[103:0104) |   └─Token(RightParen) |)|
-//@[104:0106) ├─Token(NewLine) |\r\n|
+//@[104:0108) ├─Token(NewLine) |\r\n\r\n|
+
+var testYaml = loadYamlContent('./Assets/test.yaml.txt')
+//@[000:0056) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0012) | ├─IdentifierSyntax
+//@[004:0012) | | └─Token(Identifier) |testYaml|
+//@[013:0014) | ├─Token(Assignment) |=|
+//@[015:0056) | └─FunctionCallSyntax
+//@[015:0030) |   ├─IdentifierSyntax
+//@[015:0030) |   | └─Token(Identifier) |loadYamlContent|
+//@[030:0031) |   ├─Token(LeftParen) |(|
+//@[031:0055) |   ├─FunctionArgumentSyntax
+//@[031:0055) |   | └─StringSyntax
+//@[031:0055) |   |   └─Token(StringComplete) |'./Assets/test.yaml.txt'|
+//@[055:0056) |   └─Token(RightParen) |)|
+//@[056:0058) ├─Token(NewLine) |\r\n|
+var testYamlString = testYaml.string
+//@[000:0036) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0018) | ├─IdentifierSyntax
+//@[004:0018) | | └─Token(Identifier) |testYamlString|
+//@[019:0020) | ├─Token(Assignment) |=|
+//@[021:0036) | └─PropertyAccessSyntax
+//@[021:0029) |   ├─VariableAccessSyntax
+//@[021:0029) |   | └─IdentifierSyntax
+//@[021:0029) |   |   └─Token(Identifier) |testYaml|
+//@[029:0030) |   ├─Token(Dot) |.|
+//@[030:0036) |   └─IdentifierSyntax
+//@[030:0036) |     └─Token(Identifier) |string|
+//@[036:0038) ├─Token(NewLine) |\r\n|
+var testYamlInt = testYaml.int
+//@[000:0030) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0015) | ├─IdentifierSyntax
+//@[004:0015) | | └─Token(Identifier) |testYamlInt|
+//@[016:0017) | ├─Token(Assignment) |=|
+//@[018:0030) | └─PropertyAccessSyntax
+//@[018:0026) |   ├─VariableAccessSyntax
+//@[018:0026) |   | └─IdentifierSyntax
+//@[018:0026) |   |   └─Token(Identifier) |testYaml|
+//@[026:0027) |   ├─Token(Dot) |.|
+//@[027:0030) |   └─IdentifierSyntax
+//@[027:0030) |     └─Token(Identifier) |int|
+//@[030:0032) ├─Token(NewLine) |\r\n|
+var testYamlBool = testYaml.bool
+//@[000:0032) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0016) | ├─IdentifierSyntax
+//@[004:0016) | | └─Token(Identifier) |testYamlBool|
+//@[017:0018) | ├─Token(Assignment) |=|
+//@[019:0032) | └─PropertyAccessSyntax
+//@[019:0027) |   ├─VariableAccessSyntax
+//@[019:0027) |   | └─IdentifierSyntax
+//@[019:0027) |   |   └─Token(Identifier) |testYaml|
+//@[027:0028) |   ├─Token(Dot) |.|
+//@[028:0032) |   └─IdentifierSyntax
+//@[028:0032) |     └─Token(Identifier) |bool|
+//@[032:0034) ├─Token(NewLine) |\r\n|
+var testYamlArrayInt = testYaml.arrayInt
+//@[000:0040) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0020) | ├─IdentifierSyntax
+//@[004:0020) | | └─Token(Identifier) |testYamlArrayInt|
+//@[021:0022) | ├─Token(Assignment) |=|
+//@[023:0040) | └─PropertyAccessSyntax
+//@[023:0031) |   ├─VariableAccessSyntax
+//@[023:0031) |   | └─IdentifierSyntax
+//@[023:0031) |   |   └─Token(Identifier) |testYaml|
+//@[031:0032) |   ├─Token(Dot) |.|
+//@[032:0040) |   └─IdentifierSyntax
+//@[032:0040) |     └─Token(Identifier) |arrayInt|
+//@[040:0042) ├─Token(NewLine) |\r\n|
+var testYamlArrayIntVal = testYaml.arrayInt[0]
+//@[000:0046) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0023) | ├─IdentifierSyntax
+//@[004:0023) | | └─Token(Identifier) |testYamlArrayIntVal|
+//@[024:0025) | ├─Token(Assignment) |=|
+//@[026:0046) | └─ArrayAccessSyntax
+//@[026:0043) |   ├─PropertyAccessSyntax
+//@[026:0034) |   | ├─VariableAccessSyntax
+//@[026:0034) |   | | └─IdentifierSyntax
+//@[026:0034) |   | |   └─Token(Identifier) |testYaml|
+//@[034:0035) |   | ├─Token(Dot) |.|
+//@[035:0043) |   | └─IdentifierSyntax
+//@[035:0043) |   |   └─Token(Identifier) |arrayInt|
+//@[043:0044) |   ├─Token(LeftSquare) |[|
+//@[044:0045) |   ├─IntegerLiteralSyntax
+//@[044:0045) |   | └─Token(Integer) |0|
+//@[045:0046) |   └─Token(RightSquare) |]|
+//@[046:0048) ├─Token(NewLine) |\r\n|
+var testYamlArrayString = testYaml.arrayString
+//@[000:0046) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0023) | ├─IdentifierSyntax
+//@[004:0023) | | └─Token(Identifier) |testYamlArrayString|
+//@[024:0025) | ├─Token(Assignment) |=|
+//@[026:0046) | └─PropertyAccessSyntax
+//@[026:0034) |   ├─VariableAccessSyntax
+//@[026:0034) |   | └─IdentifierSyntax
+//@[026:0034) |   |   └─Token(Identifier) |testYaml|
+//@[034:0035) |   ├─Token(Dot) |.|
+//@[035:0046) |   └─IdentifierSyntax
+//@[035:0046) |     └─Token(Identifier) |arrayString|
+//@[046:0048) ├─Token(NewLine) |\r\n|
+var testYamlArrayStringVal = testYaml.arrayString[0]
+//@[000:0052) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0026) | ├─IdentifierSyntax
+//@[004:0026) | | └─Token(Identifier) |testYamlArrayStringVal|
+//@[027:0028) | ├─Token(Assignment) |=|
+//@[029:0052) | └─ArrayAccessSyntax
+//@[029:0049) |   ├─PropertyAccessSyntax
+//@[029:0037) |   | ├─VariableAccessSyntax
+//@[029:0037) |   | | └─IdentifierSyntax
+//@[029:0037) |   | |   └─Token(Identifier) |testYaml|
+//@[037:0038) |   | ├─Token(Dot) |.|
+//@[038:0049) |   | └─IdentifierSyntax
+//@[038:0049) |   |   └─Token(Identifier) |arrayString|
+//@[049:0050) |   ├─Token(LeftSquare) |[|
+//@[050:0051) |   ├─IntegerLiteralSyntax
+//@[050:0051) |   | └─Token(Integer) |0|
+//@[051:0052) |   └─Token(RightSquare) |]|
+//@[052:0054) ├─Token(NewLine) |\r\n|
+var testYamlArrayBool = testYaml.arrayBool
+//@[000:0042) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0021) | ├─IdentifierSyntax
+//@[004:0021) | | └─Token(Identifier) |testYamlArrayBool|
+//@[022:0023) | ├─Token(Assignment) |=|
+//@[024:0042) | └─PropertyAccessSyntax
+//@[024:0032) |   ├─VariableAccessSyntax
+//@[024:0032) |   | └─IdentifierSyntax
+//@[024:0032) |   |   └─Token(Identifier) |testYaml|
+//@[032:0033) |   ├─Token(Dot) |.|
+//@[033:0042) |   └─IdentifierSyntax
+//@[033:0042) |     └─Token(Identifier) |arrayBool|
+//@[042:0044) ├─Token(NewLine) |\r\n|
+var testYamlArrayBoolVal = testYaml.arrayBool[0]
+//@[000:0048) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0024) | ├─IdentifierSyntax
+//@[004:0024) | | └─Token(Identifier) |testYamlArrayBoolVal|
+//@[025:0026) | ├─Token(Assignment) |=|
+//@[027:0048) | └─ArrayAccessSyntax
+//@[027:0045) |   ├─PropertyAccessSyntax
+//@[027:0035) |   | ├─VariableAccessSyntax
+//@[027:0035) |   | | └─IdentifierSyntax
+//@[027:0035) |   | |   └─Token(Identifier) |testYaml|
+//@[035:0036) |   | ├─Token(Dot) |.|
+//@[036:0045) |   | └─IdentifierSyntax
+//@[036:0045) |   |   └─Token(Identifier) |arrayBool|
+//@[045:0046) |   ├─Token(LeftSquare) |[|
+//@[046:0047) |   ├─IntegerLiteralSyntax
+//@[046:0047) |   | └─Token(Integer) |0|
+//@[047:0048) |   └─Token(RightSquare) |]|
+//@[048:0050) ├─Token(NewLine) |\r\n|
+var testYamlObject = testYaml.object
+//@[000:0036) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0018) | ├─IdentifierSyntax
+//@[004:0018) | | └─Token(Identifier) |testYamlObject|
+//@[019:0020) | ├─Token(Assignment) |=|
+//@[021:0036) | └─PropertyAccessSyntax
+//@[021:0029) |   ├─VariableAccessSyntax
+//@[021:0029) |   | └─IdentifierSyntax
+//@[021:0029) |   |   └─Token(Identifier) |testYaml|
+//@[029:0030) |   ├─Token(Dot) |.|
+//@[030:0036) |   └─IdentifierSyntax
+//@[030:0036) |     └─Token(Identifier) |object|
+//@[036:0038) ├─Token(NewLine) |\r\n|
+var testYamlObjectNestedString = testYaml.object.nestedString
+//@[000:0061) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0030) | ├─IdentifierSyntax
+//@[004:0030) | | └─Token(Identifier) |testYamlObjectNestedString|
+//@[031:0032) | ├─Token(Assignment) |=|
+//@[033:0061) | └─PropertyAccessSyntax
+//@[033:0048) |   ├─PropertyAccessSyntax
+//@[033:0041) |   | ├─VariableAccessSyntax
+//@[033:0041) |   | | └─IdentifierSyntax
+//@[033:0041) |   | |   └─Token(Identifier) |testYaml|
+//@[041:0042) |   | ├─Token(Dot) |.|
+//@[042:0048) |   | └─IdentifierSyntax
+//@[042:0048) |   |   └─Token(Identifier) |object|
+//@[048:0049) |   ├─Token(Dot) |.|
+//@[049:0061) |   └─IdentifierSyntax
+//@[049:0061) |     └─Token(Identifier) |nestedString|
+//@[061:0063) ├─Token(NewLine) |\r\n|
+var testYamlObjectNestedInt = testYaml.object.nestedInt
+//@[000:0055) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0027) | ├─IdentifierSyntax
+//@[004:0027) | | └─Token(Identifier) |testYamlObjectNestedInt|
+//@[028:0029) | ├─Token(Assignment) |=|
+//@[030:0055) | └─PropertyAccessSyntax
+//@[030:0045) |   ├─PropertyAccessSyntax
+//@[030:0038) |   | ├─VariableAccessSyntax
+//@[030:0038) |   | | └─IdentifierSyntax
+//@[030:0038) |   | |   └─Token(Identifier) |testYaml|
+//@[038:0039) |   | ├─Token(Dot) |.|
+//@[039:0045) |   | └─IdentifierSyntax
+//@[039:0045) |   |   └─Token(Identifier) |object|
+//@[045:0046) |   ├─Token(Dot) |.|
+//@[046:0055) |   └─IdentifierSyntax
+//@[046:0055) |     └─Token(Identifier) |nestedInt|
+//@[055:0057) ├─Token(NewLine) |\r\n|
+var testYamlObjectNestedBool = testYaml.object.nestedBool
+//@[000:0057) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0028) | ├─IdentifierSyntax
+//@[004:0028) | | └─Token(Identifier) |testYamlObjectNestedBool|
+//@[029:0030) | ├─Token(Assignment) |=|
+//@[031:0057) | └─PropertyAccessSyntax
+//@[031:0046) |   ├─PropertyAccessSyntax
+//@[031:0039) |   | ├─VariableAccessSyntax
+//@[031:0039) |   | | └─IdentifierSyntax
+//@[031:0039) |   | |   └─Token(Identifier) |testYaml|
+//@[039:0040) |   | ├─Token(Dot) |.|
+//@[040:0046) |   | └─IdentifierSyntax
+//@[040:0046) |   |   └─Token(Identifier) |object|
+//@[046:0047) |   ├─Token(Dot) |.|
+//@[047:0057) |   └─IdentifierSyntax
+//@[047:0057) |     └─Token(Identifier) |nestedBool|
+//@[057:0061) ├─Token(NewLine) |\r\n\r\n|
+
+output testYamlString string = testYamlString
+//@[000:0045) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0021) | ├─IdentifierSyntax
+//@[007:0021) | | └─Token(Identifier) |testYamlString|
+//@[022:0028) | ├─VariableAccessSyntax
+//@[022:0028) | | └─IdentifierSyntax
+//@[022:0028) | |   └─Token(Identifier) |string|
+//@[029:0030) | ├─Token(Assignment) |=|
+//@[031:0045) | └─VariableAccessSyntax
+//@[031:0045) |   └─IdentifierSyntax
+//@[031:0045) |     └─Token(Identifier) |testYamlString|
+//@[045:0047) ├─Token(NewLine) |\r\n|
+output testYamlInt int = testYamlInt
+//@[000:0036) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0018) | ├─IdentifierSyntax
+//@[007:0018) | | └─Token(Identifier) |testYamlInt|
+//@[019:0022) | ├─VariableAccessSyntax
+//@[019:0022) | | └─IdentifierSyntax
+//@[019:0022) | |   └─Token(Identifier) |int|
+//@[023:0024) | ├─Token(Assignment) |=|
+//@[025:0036) | └─VariableAccessSyntax
+//@[025:0036) |   └─IdentifierSyntax
+//@[025:0036) |     └─Token(Identifier) |testYamlInt|
+//@[036:0038) ├─Token(NewLine) |\r\n|
+output testYamlBool bool = testYamlBool
+//@[000:0039) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0019) | ├─IdentifierSyntax
+//@[007:0019) | | └─Token(Identifier) |testYamlBool|
+//@[020:0024) | ├─VariableAccessSyntax
+//@[020:0024) | | └─IdentifierSyntax
+//@[020:0024) | |   └─Token(Identifier) |bool|
+//@[025:0026) | ├─Token(Assignment) |=|
+//@[027:0039) | └─VariableAccessSyntax
+//@[027:0039) |   └─IdentifierSyntax
+//@[027:0039) |     └─Token(Identifier) |testYamlBool|
+//@[039:0041) ├─Token(NewLine) |\r\n|
+output testYamlArrayInt array = testYamlArrayInt
+//@[000:0048) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0023) | ├─IdentifierSyntax
+//@[007:0023) | | └─Token(Identifier) |testYamlArrayInt|
+//@[024:0029) | ├─VariableAccessSyntax
+//@[024:0029) | | └─IdentifierSyntax
+//@[024:0029) | |   └─Token(Identifier) |array|
+//@[030:0031) | ├─Token(Assignment) |=|
+//@[032:0048) | └─VariableAccessSyntax
+//@[032:0048) |   └─IdentifierSyntax
+//@[032:0048) |     └─Token(Identifier) |testYamlArrayInt|
+//@[048:0050) ├─Token(NewLine) |\r\n|
+output testYamlArrayIntVal int = testYamlArrayIntVal
+//@[000:0052) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0026) | ├─IdentifierSyntax
+//@[007:0026) | | └─Token(Identifier) |testYamlArrayIntVal|
+//@[027:0030) | ├─VariableAccessSyntax
+//@[027:0030) | | └─IdentifierSyntax
+//@[027:0030) | |   └─Token(Identifier) |int|
+//@[031:0032) | ├─Token(Assignment) |=|
+//@[033:0052) | └─VariableAccessSyntax
+//@[033:0052) |   └─IdentifierSyntax
+//@[033:0052) |     └─Token(Identifier) |testYamlArrayIntVal|
+//@[052:0054) ├─Token(NewLine) |\r\n|
+output testYamlArrayString array = testYamlArrayString
+//@[000:0054) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0026) | ├─IdentifierSyntax
+//@[007:0026) | | └─Token(Identifier) |testYamlArrayString|
+//@[027:0032) | ├─VariableAccessSyntax
+//@[027:0032) | | └─IdentifierSyntax
+//@[027:0032) | |   └─Token(Identifier) |array|
+//@[033:0034) | ├─Token(Assignment) |=|
+//@[035:0054) | └─VariableAccessSyntax
+//@[035:0054) |   └─IdentifierSyntax
+//@[035:0054) |     └─Token(Identifier) |testYamlArrayString|
+//@[054:0056) ├─Token(NewLine) |\r\n|
+output testYamlArrayStringVal string = testYamlArrayStringVal
+//@[000:0061) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0029) | ├─IdentifierSyntax
+//@[007:0029) | | └─Token(Identifier) |testYamlArrayStringVal|
+//@[030:0036) | ├─VariableAccessSyntax
+//@[030:0036) | | └─IdentifierSyntax
+//@[030:0036) | |   └─Token(Identifier) |string|
+//@[037:0038) | ├─Token(Assignment) |=|
+//@[039:0061) | └─VariableAccessSyntax
+//@[039:0061) |   └─IdentifierSyntax
+//@[039:0061) |     └─Token(Identifier) |testYamlArrayStringVal|
+//@[061:0063) ├─Token(NewLine) |\r\n|
+output testYamlArrayBool array = testYamlArrayBool
+//@[000:0050) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0024) | ├─IdentifierSyntax
+//@[007:0024) | | └─Token(Identifier) |testYamlArrayBool|
+//@[025:0030) | ├─VariableAccessSyntax
+//@[025:0030) | | └─IdentifierSyntax
+//@[025:0030) | |   └─Token(Identifier) |array|
+//@[031:0032) | ├─Token(Assignment) |=|
+//@[033:0050) | └─VariableAccessSyntax
+//@[033:0050) |   └─IdentifierSyntax
+//@[033:0050) |     └─Token(Identifier) |testYamlArrayBool|
+//@[050:0052) ├─Token(NewLine) |\r\n|
+output testYamlArrayBoolVal bool = testYamlArrayBoolVal
+//@[000:0055) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0027) | ├─IdentifierSyntax
+//@[007:0027) | | └─Token(Identifier) |testYamlArrayBoolVal|
+//@[028:0032) | ├─VariableAccessSyntax
+//@[028:0032) | | └─IdentifierSyntax
+//@[028:0032) | |   └─Token(Identifier) |bool|
+//@[033:0034) | ├─Token(Assignment) |=|
+//@[035:0055) | └─VariableAccessSyntax
+//@[035:0055) |   └─IdentifierSyntax
+//@[035:0055) |     └─Token(Identifier) |testYamlArrayBoolVal|
+//@[055:0057) ├─Token(NewLine) |\r\n|
+output testYamlObject object = testYamlObject
+//@[000:0045) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0021) | ├─IdentifierSyntax
+//@[007:0021) | | └─Token(Identifier) |testYamlObject|
+//@[022:0028) | ├─VariableAccessSyntax
+//@[022:0028) | | └─IdentifierSyntax
+//@[022:0028) | |   └─Token(Identifier) |object|
+//@[029:0030) | ├─Token(Assignment) |=|
+//@[031:0045) | └─VariableAccessSyntax
+//@[031:0045) |   └─IdentifierSyntax
+//@[031:0045) |     └─Token(Identifier) |testYamlObject|
+//@[045:0047) ├─Token(NewLine) |\r\n|
+output testYamlObjectNestedString string = testYamlObjectNestedString
+//@[000:0069) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0033) | ├─IdentifierSyntax
+//@[007:0033) | | └─Token(Identifier) |testYamlObjectNestedString|
+//@[034:0040) | ├─VariableAccessSyntax
+//@[034:0040) | | └─IdentifierSyntax
+//@[034:0040) | |   └─Token(Identifier) |string|
+//@[041:0042) | ├─Token(Assignment) |=|
+//@[043:0069) | └─VariableAccessSyntax
+//@[043:0069) |   └─IdentifierSyntax
+//@[043:0069) |     └─Token(Identifier) |testYamlObjectNestedString|
+//@[069:0071) ├─Token(NewLine) |\r\n|
+output testYamlObjectNestedInt int = testYamlObjectNestedInt
+//@[000:0060) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0030) | ├─IdentifierSyntax
+//@[007:0030) | | └─Token(Identifier) |testYamlObjectNestedInt|
+//@[031:0034) | ├─VariableAccessSyntax
+//@[031:0034) | | └─IdentifierSyntax
+//@[031:0034) | |   └─Token(Identifier) |int|
+//@[035:0036) | ├─Token(Assignment) |=|
+//@[037:0060) | └─VariableAccessSyntax
+//@[037:0060) |   └─IdentifierSyntax
+//@[037:0060) |     └─Token(Identifier) |testYamlObjectNestedInt|
+//@[060:0062) ├─Token(NewLine) |\r\n|
+output testYamlObjectNestedBool bool = testYamlObjectNestedBool
+//@[000:0063) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0031) | ├─IdentifierSyntax
+//@[007:0031) | | └─Token(Identifier) |testYamlObjectNestedBool|
+//@[032:0036) | ├─VariableAccessSyntax
+//@[032:0036) | | └─IdentifierSyntax
+//@[032:0036) | |   └─Token(Identifier) |bool|
+//@[037:0038) | ├─Token(Assignment) |=|
+//@[039:0063) | └─VariableAccessSyntax
+//@[039:0063) |   └─IdentifierSyntax
+//@[039:0063) |     └─Token(Identifier) |testYamlObjectNestedBool|
+//@[063:0065) ├─Token(NewLine) |\r\n|
 
 //@[000:0000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.tokens.bicep
@@ -617,6 +617,227 @@ var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.product
 //@[069:070) Comma |,|
 //@[071:103) StringComplete |'.products[?(@.price > 3)].name'|
 //@[103:104) RightParen |)|
-//@[104:106) NewLine |\r\n|
+//@[104:108) NewLine |\r\n\r\n|
+
+var testYaml = loadYamlContent('./Assets/test.yaml.txt')
+//@[000:003) Identifier |var|
+//@[004:012) Identifier |testYaml|
+//@[013:014) Assignment |=|
+//@[015:030) Identifier |loadYamlContent|
+//@[030:031) LeftParen |(|
+//@[031:055) StringComplete |'./Assets/test.yaml.txt'|
+//@[055:056) RightParen |)|
+//@[056:058) NewLine |\r\n|
+var testYamlString = testYaml.string
+//@[000:003) Identifier |var|
+//@[004:018) Identifier |testYamlString|
+//@[019:020) Assignment |=|
+//@[021:029) Identifier |testYaml|
+//@[029:030) Dot |.|
+//@[030:036) Identifier |string|
+//@[036:038) NewLine |\r\n|
+var testYamlInt = testYaml.int
+//@[000:003) Identifier |var|
+//@[004:015) Identifier |testYamlInt|
+//@[016:017) Assignment |=|
+//@[018:026) Identifier |testYaml|
+//@[026:027) Dot |.|
+//@[027:030) Identifier |int|
+//@[030:032) NewLine |\r\n|
+var testYamlBool = testYaml.bool
+//@[000:003) Identifier |var|
+//@[004:016) Identifier |testYamlBool|
+//@[017:018) Assignment |=|
+//@[019:027) Identifier |testYaml|
+//@[027:028) Dot |.|
+//@[028:032) Identifier |bool|
+//@[032:034) NewLine |\r\n|
+var testYamlArrayInt = testYaml.arrayInt
+//@[000:003) Identifier |var|
+//@[004:020) Identifier |testYamlArrayInt|
+//@[021:022) Assignment |=|
+//@[023:031) Identifier |testYaml|
+//@[031:032) Dot |.|
+//@[032:040) Identifier |arrayInt|
+//@[040:042) NewLine |\r\n|
+var testYamlArrayIntVal = testYaml.arrayInt[0]
+//@[000:003) Identifier |var|
+//@[004:023) Identifier |testYamlArrayIntVal|
+//@[024:025) Assignment |=|
+//@[026:034) Identifier |testYaml|
+//@[034:035) Dot |.|
+//@[035:043) Identifier |arrayInt|
+//@[043:044) LeftSquare |[|
+//@[044:045) Integer |0|
+//@[045:046) RightSquare |]|
+//@[046:048) NewLine |\r\n|
+var testYamlArrayString = testYaml.arrayString
+//@[000:003) Identifier |var|
+//@[004:023) Identifier |testYamlArrayString|
+//@[024:025) Assignment |=|
+//@[026:034) Identifier |testYaml|
+//@[034:035) Dot |.|
+//@[035:046) Identifier |arrayString|
+//@[046:048) NewLine |\r\n|
+var testYamlArrayStringVal = testYaml.arrayString[0]
+//@[000:003) Identifier |var|
+//@[004:026) Identifier |testYamlArrayStringVal|
+//@[027:028) Assignment |=|
+//@[029:037) Identifier |testYaml|
+//@[037:038) Dot |.|
+//@[038:049) Identifier |arrayString|
+//@[049:050) LeftSquare |[|
+//@[050:051) Integer |0|
+//@[051:052) RightSquare |]|
+//@[052:054) NewLine |\r\n|
+var testYamlArrayBool = testYaml.arrayBool
+//@[000:003) Identifier |var|
+//@[004:021) Identifier |testYamlArrayBool|
+//@[022:023) Assignment |=|
+//@[024:032) Identifier |testYaml|
+//@[032:033) Dot |.|
+//@[033:042) Identifier |arrayBool|
+//@[042:044) NewLine |\r\n|
+var testYamlArrayBoolVal = testYaml.arrayBool[0]
+//@[000:003) Identifier |var|
+//@[004:024) Identifier |testYamlArrayBoolVal|
+//@[025:026) Assignment |=|
+//@[027:035) Identifier |testYaml|
+//@[035:036) Dot |.|
+//@[036:045) Identifier |arrayBool|
+//@[045:046) LeftSquare |[|
+//@[046:047) Integer |0|
+//@[047:048) RightSquare |]|
+//@[048:050) NewLine |\r\n|
+var testYamlObject = testYaml.object
+//@[000:003) Identifier |var|
+//@[004:018) Identifier |testYamlObject|
+//@[019:020) Assignment |=|
+//@[021:029) Identifier |testYaml|
+//@[029:030) Dot |.|
+//@[030:036) Identifier |object|
+//@[036:038) NewLine |\r\n|
+var testYamlObjectNestedString = testYaml.object.nestedString
+//@[000:003) Identifier |var|
+//@[004:030) Identifier |testYamlObjectNestedString|
+//@[031:032) Assignment |=|
+//@[033:041) Identifier |testYaml|
+//@[041:042) Dot |.|
+//@[042:048) Identifier |object|
+//@[048:049) Dot |.|
+//@[049:061) Identifier |nestedString|
+//@[061:063) NewLine |\r\n|
+var testYamlObjectNestedInt = testYaml.object.nestedInt
+//@[000:003) Identifier |var|
+//@[004:027) Identifier |testYamlObjectNestedInt|
+//@[028:029) Assignment |=|
+//@[030:038) Identifier |testYaml|
+//@[038:039) Dot |.|
+//@[039:045) Identifier |object|
+//@[045:046) Dot |.|
+//@[046:055) Identifier |nestedInt|
+//@[055:057) NewLine |\r\n|
+var testYamlObjectNestedBool = testYaml.object.nestedBool
+//@[000:003) Identifier |var|
+//@[004:028) Identifier |testYamlObjectNestedBool|
+//@[029:030) Assignment |=|
+//@[031:039) Identifier |testYaml|
+//@[039:040) Dot |.|
+//@[040:046) Identifier |object|
+//@[046:047) Dot |.|
+//@[047:057) Identifier |nestedBool|
+//@[057:061) NewLine |\r\n\r\n|
+
+output testYamlString string = testYamlString
+//@[000:006) Identifier |output|
+//@[007:021) Identifier |testYamlString|
+//@[022:028) Identifier |string|
+//@[029:030) Assignment |=|
+//@[031:045) Identifier |testYamlString|
+//@[045:047) NewLine |\r\n|
+output testYamlInt int = testYamlInt
+//@[000:006) Identifier |output|
+//@[007:018) Identifier |testYamlInt|
+//@[019:022) Identifier |int|
+//@[023:024) Assignment |=|
+//@[025:036) Identifier |testYamlInt|
+//@[036:038) NewLine |\r\n|
+output testYamlBool bool = testYamlBool
+//@[000:006) Identifier |output|
+//@[007:019) Identifier |testYamlBool|
+//@[020:024) Identifier |bool|
+//@[025:026) Assignment |=|
+//@[027:039) Identifier |testYamlBool|
+//@[039:041) NewLine |\r\n|
+output testYamlArrayInt array = testYamlArrayInt
+//@[000:006) Identifier |output|
+//@[007:023) Identifier |testYamlArrayInt|
+//@[024:029) Identifier |array|
+//@[030:031) Assignment |=|
+//@[032:048) Identifier |testYamlArrayInt|
+//@[048:050) NewLine |\r\n|
+output testYamlArrayIntVal int = testYamlArrayIntVal
+//@[000:006) Identifier |output|
+//@[007:026) Identifier |testYamlArrayIntVal|
+//@[027:030) Identifier |int|
+//@[031:032) Assignment |=|
+//@[033:052) Identifier |testYamlArrayIntVal|
+//@[052:054) NewLine |\r\n|
+output testYamlArrayString array = testYamlArrayString
+//@[000:006) Identifier |output|
+//@[007:026) Identifier |testYamlArrayString|
+//@[027:032) Identifier |array|
+//@[033:034) Assignment |=|
+//@[035:054) Identifier |testYamlArrayString|
+//@[054:056) NewLine |\r\n|
+output testYamlArrayStringVal string = testYamlArrayStringVal
+//@[000:006) Identifier |output|
+//@[007:029) Identifier |testYamlArrayStringVal|
+//@[030:036) Identifier |string|
+//@[037:038) Assignment |=|
+//@[039:061) Identifier |testYamlArrayStringVal|
+//@[061:063) NewLine |\r\n|
+output testYamlArrayBool array = testYamlArrayBool
+//@[000:006) Identifier |output|
+//@[007:024) Identifier |testYamlArrayBool|
+//@[025:030) Identifier |array|
+//@[031:032) Assignment |=|
+//@[033:050) Identifier |testYamlArrayBool|
+//@[050:052) NewLine |\r\n|
+output testYamlArrayBoolVal bool = testYamlArrayBoolVal
+//@[000:006) Identifier |output|
+//@[007:027) Identifier |testYamlArrayBoolVal|
+//@[028:032) Identifier |bool|
+//@[033:034) Assignment |=|
+//@[035:055) Identifier |testYamlArrayBoolVal|
+//@[055:057) NewLine |\r\n|
+output testYamlObject object = testYamlObject
+//@[000:006) Identifier |output|
+//@[007:021) Identifier |testYamlObject|
+//@[022:028) Identifier |object|
+//@[029:030) Assignment |=|
+//@[031:045) Identifier |testYamlObject|
+//@[045:047) NewLine |\r\n|
+output testYamlObjectNestedString string = testYamlObjectNestedString
+//@[000:006) Identifier |output|
+//@[007:033) Identifier |testYamlObjectNestedString|
+//@[034:040) Identifier |string|
+//@[041:042) Assignment |=|
+//@[043:069) Identifier |testYamlObjectNestedString|
+//@[069:071) NewLine |\r\n|
+output testYamlObjectNestedInt int = testYamlObjectNestedInt
+//@[000:006) Identifier |output|
+//@[007:030) Identifier |testYamlObjectNestedInt|
+//@[031:034) Identifier |int|
+//@[035:036) Assignment |=|
+//@[037:060) Identifier |testYamlObjectNestedInt|
+//@[060:062) NewLine |\r\n|
+output testYamlObjectNestedBool bool = testYamlObjectNestedBool
+//@[000:006) Identifier |output|
+//@[007:031) Identifier |testYamlObjectNestedBool|
+//@[032:036) Identifier |bool|
+//@[037:038) Assignment |=|
+//@[039:063) Identifier |testYamlObjectNestedBool|
+//@[063:065) NewLine |\r\n|
 
 //@[000:000) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
@@ -1548,6 +1548,27 @@
     }
   },
   {
+    "label": "loadYamlContent",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nloadYamlContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_loadYamlContent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "loadYamlContent($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "loginEndpoint",
     "kind": "variable",
     "detail": "loginEndpoint",

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -2001,6 +2001,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.Core.UnitTests/Semantics/YamlDeserializationTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/YamlDeserializationTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using Bicep.Core.Semantics;
+using Bicep.Core.Diagnostics;
+using System.Reflection;
+using Bicep.Core.Parsing;
+using Bicep.Core.Syntax;
+using Bicep.Core.Semantics.Namespaces;
+
+namespace Bicep.Core.UnitTests.Semantics
+{
+
+    [TestClass]
+    public class YamlDeserializationTests
+    {
+
+        private const string SIMPLE_JSON = """
+            {
+              "string": "someVal",
+              "string1": "10",
+              "int": 123,
+              "array": [
+                1,
+                2
+              ],
+              "object": {
+                "nestedString": "someVal",
+                "nestedObject": {
+                  "nestedInt": 1
+                },
+                "nestedArray": [
+                  1,
+                  2
+                ]
+              }
+            }
+            """;
+
+        private const string COMPLEX_JSON = """
+            {
+              "label": "dateTimeFromEpoch",
+              "kind": "function",
+              "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n",
+              "documentation": {
+                "kind": "markdown",
+                "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+              },
+              "deprecated": false,
+              "preselect": false,
+              "sortText": "3_dateTimeFromEpoch",
+              "insertTextFormat": "snippet",
+              "insertTextMode": "adjustIndentation",
+              "textEdit": {
+                "range": {},
+                "newText": "dateTimeFromEpoch($0)"
+                },
+              "command": {
+                "title": "signature help",
+                "command": "editor.action.triggerParameterHints"
+              }
+            }
+            """;
+
+        [TestMethod]
+        public void Commented_YAML_file_content_gets_deserialized_into_JSON()
+        {
+            var yml = @"
+                string: someVal
+                int: 123
+                array:
+                - 1
+                # comment
+                - 2
+                #comment
+                object: #more comments
+                    nestedString: someVal
+                    nestedObject:
+                        nestedInt: 1
+                    nestedArray:
+                    - 1
+                    - 2";
+
+            CompareSimpleJSON(yml);
+        }
+
+        [TestMethod]
+        public void JSON_file_content_gets_deserialized_into_JSON()
+        {
+            var json = SIMPLE_JSON;
+            CompareSimpleJSON(json);
+        }
+
+        private static void CompareSimpleJSON(string json)
+        {
+            var arguments = new FunctionArgumentSyntax[4];
+            new YamlObjectParser().TryExtractFromObject(json, null, new IPositionable[] { arguments[0] }, out var errorDiagnostic, out JToken jToken);
+            var correctList = new List<int> { 1, 2 };
+            var correctObject = new Dictionary<string, int> { { "nestedInt", 1 }, };
+
+            Assert.AreEqual("someVal", jToken["string"]);
+            Assert.AreEqual(123, jToken["int"]);
+
+            CollectionAssert.AreEqual(correctList, jToken["array"]?.ToObject<List<int>>());
+            Assert.AreEqual(1, jToken["array"]![0]);
+            Assert.AreEqual(2, jToken["array"]![1]);
+
+            CollectionAssert.AreEqual(correctObject, jToken["object"]?["nestedObject"]?.ToObject<Dictionary<string, int>>());
+            Assert.AreEqual("someVal", jToken["object"]?["nestedString"]);
+
+            Assert.AreEqual(1, jToken["object"]?["nestedObject"]?["nestedInt"]);
+            Assert.AreEqual(1, jToken["object"]?["nestedArray"]![0]);
+            Assert.AreEqual(2, jToken["object"]?["nestedArray"]![1]);
+        }
+
+
+        [TestMethod]
+        public void Complex_JSON_gets_deserialized_into_JSON()
+        {
+            var json = COMPLEX_JSON;
+            var arguments = new FunctionArgumentSyntax[4];
+            new YamlObjectParser().TryExtractFromObject(json, null, new IPositionable[] { arguments[0] }, out var errorDiagnostic, out JToken jToken);
+            var expectedValue = "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n";
+            Assert.AreEqual(expectedValue, jToken["documentation"]!["value"]);
+        }
+
+
+        [TestMethod]
+        public void Simple_YAML_file_content_gets_deserialized_into_JSON()
+        {
+            var yml = @"
+                 name: George Washington
+                 age: 89
+                 height_in_inches: 5.75
+                 addresses:
+                   home:
+                     street:
+                        house_number: '400'
+                        street_name: Mockingbird Lane
+                     city: Louaryland
+                     state: Hawidaho
+                     zip: 99970";
+
+            var arguments = new FunctionArgumentSyntax[4];
+            new YamlObjectParser().TryExtractFromObject(yml, null, new IPositionable[] { arguments[0] }, out var errorDiagnostic, out JToken jToken);
+
+            Assert.AreEqual("George Washington", jToken["name"]);
+            Assert.AreEqual("400", jToken["addresses"]!["home"]!["street"]!["house_number"]);
+            Assert.AreEqual(89, jToken["age"]);
+            Assert.AreEqual("Louaryland", jToken["addresses"]!["home"]!["city"]);
+        }
+    }
+
+}

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -2010,6 +2010,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="SharpYaml" Version="2.1.0" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="Azure.Deployments.Core" Version="1.0.872" />
     <PackageReference Include="Azure.Deployments.Templates" Version="1.0.872" />

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1910,11 +1910,16 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP338",
                 $"Failed to evaluate parameter \"{parameterName}\": {message}");
-                
+
             public ErrorDiagnostic ArrayIndexOutOfBounds(long indexSought) => new(
-                TextSpan, 
+                TextSpan,
                 "BCP339",
                 $"""The provided array index value of "{indexSought}" is not valid. Array index should be greater than or equal to 0.""");
+
+            public ErrorDiagnostic UnparseableYamlType() => new(
+               TextSpan,
+               "BCP340",
+               $"Unable to parse literal YAML value. Please ensure that it is well-formed. Comments in YAML must use #, and do not support // or /**/.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -184,6 +184,7 @@ namespace Bicep.Core
 
         public static readonly TypeSymbol StringFilePath = TypeFactory.CreateStringType(validationFlags: TypeSymbolValidationFlags.IsStringFilePath);
         public static readonly TypeSymbol StringJsonFilePath = TypeFactory.CreateStringType(validationFlags: TypeSymbolValidationFlags.IsStringFilePath | TypeSymbolValidationFlags.IsStringJsonFilePath);
+        public static readonly TypeSymbol StringYamlFilePath = TypeFactory.CreateStringType(validationFlags: TypeSymbolValidationFlags.IsStringFilePath | TypeSymbolValidationFlags.IsStringYamlFilePath);
 
         //Type for available loadTextContent encoding
 

--- a/src/Bicep.Core/Semantics/IObjectParser.cs
+++ b/src/Bicep.Core/Semantics/IObjectParser.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Diagnostics.CodeAnalysis;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Parsing;
+using Bicep.Core.TypeSystem;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.Semantics
+{
+    public interface IObjectParser
+    {
+        abstract bool TryExtractFromObject(string fileContent, string? tokenSelectorPath, IPositionable[] positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken);
+        abstract JToken ExtractTokenFromObject(string fileContent);
+        abstract ErrorDiagnostic GetExtractTokenErrorType(IPositionable positionable);
+        abstract bool TryExtractFromTokenByPath(JToken token, string tokenSelectorPath, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken);
+    }
+}

--- a/src/Bicep.Core/Semantics/JsonObjectParser.cs
+++ b/src/Bicep.Core/Semantics/JsonObjectParser.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Parsing;
+using Bicep.Core.TypeSystem;
+using Microsoft.WindowsAzure.ResourceStack.Common.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.Semantics
+{
+    public class JsonObjectParser : ObjectParser
+    {
+        override public JToken ExtractTokenFromObject(string fileContent)
+            => fileContent.TryFromJson<JToken>();
+        override public ErrorDiagnostic GetExtractTokenErrorType(IPositionable positionable)
+            => DiagnosticBuilder.ForPosition(positionable).UnparseableJsonType();
+    }
+}

--- a/src/Bicep.Core/Semantics/ObjectParser.cs
+++ b/src/Bicep.Core/Semantics/ObjectParser.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Intermediate;
+using Bicep.Core.Parsing;
+using Bicep.Core.TypeSystem;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SharpYaml.Serialization;
+
+namespace Bicep.Core.Semantics
+{
+    public abstract class ObjectParser : IObjectParser
+    {
+        public bool TryExtractFromObject(string fileContent, string? tokenSelectorPath, IPositionable[] positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken)
+        {
+            errorDiagnostic = null;
+            newToken = this.ExtractTokenFromObject(fileContent);
+            if (newToken is not { })
+            {
+                // Instead of catching and returning the YML parse exception, we simply return a generic error.
+                // This avoids having to deal with localization, and avoids possible confusion regarding line endings in the message.
+                errorDiagnostic = this.GetExtractTokenErrorType(positionable[0]);
+                return false;
+            }
+            if (tokenSelectorPath is not null)
+            {
+                return this.TryExtractFromTokenByPath(newToken, tokenSelectorPath, positionable[1], out errorDiagnostic, out newToken);
+            }
+            return true;
+        }
+        public abstract JToken ExtractTokenFromObject(string fileContent);
+
+        public abstract ErrorDiagnostic GetExtractTokenErrorType(IPositionable positionable);
+
+        public bool TryExtractFromTokenByPath(JToken token, string tokenSelectorPath, IPositionable positionable, [NotNullWhen(false)] out ErrorDiagnostic? errorDiagnostic, out JToken newToken)
+        {
+            newToken = token;
+            errorDiagnostic = null;
+            if (tokenSelectorPath is null)
+            {
+                return true;
+            }
+
+            try
+            {
+                var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();
+
+                switch (selectTokens.Count)
+                {
+                    case 0:
+                        {
+                            errorDiagnostic = DiagnosticBuilder.ForPosition(positionable).NoJsonTokenOnPathOrPathInvalid();
+                            return false;
+                        }
+                    case 1:
+                        {
+                            newToken = selectTokens.First();
+                            break;
+                        }
+                    default:
+                        {
+                            newToken = new JArray(selectTokens);
+                            break;
+                        }
+                }
+                return true;
+            }
+            catch (JsonException)
+            {
+                //path is invalid or user hasn't finished typing it yet
+                errorDiagnostic = DiagnosticBuilder.ForPosition(positionable).NoJsonTokenOnPathOrPathInvalid();
+                return false;
+            }
+
+
+        }
+
+    }
+}

--- a/src/Bicep.Core/Semantics/YamlObjectParser.cs
+++ b/src/Bicep.Core/Semantics/YamlObjectParser.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Parsing;
+using Bicep.Core.TypeSystem;
+using Newtonsoft.Json.Linq;
+using SharpYaml.Serialization;
+
+namespace Bicep.Core.Semantics
+{
+    public class YamlObjectParser : ObjectParser
+    {
+        override public JToken ExtractTokenFromObject(string fileContent)
+            => JToken.FromObject(new Serializer().Deserialize(fileContent)!);
+
+        override public ErrorDiagnostic GetExtractTokenErrorType(IPositionable positionable)
+            => DiagnosticBuilder.ForPosition(positionable).UnparseableYamlType();
+
+    }
+}

--- a/src/Bicep.Core/TypeSystem/TypeSymbolValidationFlags.cs
+++ b/src/Bicep.Core/TypeSystem/TypeSymbolValidationFlags.cs
@@ -44,5 +44,10 @@ namespace Bicep.Core.TypeSystem
         /// Indicates that this type will be a String file path to a JSON file and we should offer completions for it where files wih .json extension are prioritised
         /// </summary>
         IsStringJsonFilePath = 1 << 5,
+
+        /// <summary>
+        /// Indicates that this type will be a String file path to a YAML file and we should offer completions for it where files wih .yaml and .yml extension are prioritised
+        /// </summary>
+        IsStringYamlFilePath = 1 << 6,
     }
 }

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -195,6 +195,12 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "SharpYaml": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "2jBenJ6QN0mj8G3ohrNO/uNhA92OJYsQFuI5dJ4zM/HauVoC/oJzK1sCVlUaVUpuXpHUa/k1waXVkkBR2luP/w=="
+      },
       "System.Collections.Immutable": {
         "type": "Direct",
         "requested": "[7.0.0, )",

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -2006,6 +2006,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -2006,6 +2006,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -623,6 +623,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "2jBenJ6QN0mj8G3ohrNO/uNhA92OJYsQFuI5dJ4zM/HauVoC/oJzK1sCVlUaVUpuXpHUa/k1waXVkkBR2luP/w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1715,6 +1720,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -2015,6 +2015,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -2014,6 +2014,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -1246,6 +1246,13 @@ namespace Bicep.LanguageServer.Completions
                 var nonJsonItems = CreateFileCompletionItems(model.SourceFile.FileUri, context.ReplacementRange, fileCompletionInfo, (file) => !PathHelper.HasExtension(file, "json") && !PathHelper.HasExtension(file, "jsonc"), CompletionPriority.Medium);
                 fileItems = jsonItems.Concat(nonJsonItems);
             }
+            else if (argType.ValidationFlags.HasFlag(TypeSymbolValidationFlags.IsStringYamlFilePath))
+            {
+                // Prioritize .yaml or .yml files higher than other files.
+                var yamlItems = CreateFileCompletionItems(model.SourceFile.FileUri, context.ReplacementRange, fileCompletionInfo, (file) => PathHelper.HasExtension(file, "yaml") || PathHelper.HasExtension(file, "yml"), CompletionPriority.High);
+                var nonYamlItems = CreateFileCompletionItems(model.SourceFile.FileUri, context.ReplacementRange, fileCompletionInfo, (file) => !PathHelper.HasExtension(file, "yaml") && !PathHelper.HasExtension(file, "yml"), CompletionPriority.Medium);
+                fileItems = yamlItems.Concat(nonYamlItems);
+            }
             else
             {
                 fileItems = CreateFileCompletionItems(model.SourceFile.FileUri, context.ReplacementRange, fileCompletionInfo, (_) => true, CompletionPriority.High);

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -1900,6 +1900,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -960,6 +960,11 @@
           "System.IO": "4.1.0"
         }
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "2jBenJ6QN0mj8G3ohrNO/uNhA92OJYsQFuI5dJ4zM/HauVoC/oJzK1sCVlUaVUpuXpHUa/k1waXVkkBR2luP/w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2098,6 +2103,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -907,6 +907,11 @@
           "System.IO": "4.1.0"
         }
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "2jBenJ6QN0mj8G3ohrNO/uNhA92OJYsQFuI5dJ4zM/HauVoC/oJzK1sCVlUaVUpuXpHUa/k1waXVkkBR2luP/w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2040,6 +2045,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -960,6 +960,11 @@
           "System.IO": "4.1.0"
         }
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "2jBenJ6QN0mj8G3ohrNO/uNhA92OJYsQFuI5dJ4zM/HauVoC/oJzK1sCVlUaVUpuXpHUa/k1waXVkkBR2luP/w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2098,6 +2103,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -940,6 +940,11 @@
           "Serilog": "2.9.0"
         }
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "2jBenJ6QN0mj8G3ohrNO/uNhA92OJYsQFuI5dJ4zM/HauVoC/oJzK1sCVlUaVUpuXpHUa/k1waXVkkBR2luP/w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2023,6 +2028,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -2102,6 +2102,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -748,6 +748,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "2jBenJ6QN0mj8G3ohrNO/uNhA92OJYsQFuI5dJ4zM/HauVoC/oJzK1sCVlUaVUpuXpHUa/k1waXVkkBR2luP/w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1854,6 +1859,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[7.0.3, )",
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
+          "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.11, )",
           "System.Text.Json": "[8.0.0-preview.2.23128.3, )"


### PR DESCRIPTION
* add yaml tests

* add yaml tests

* nuget sync

* merge

* make yaml a regular yaml file instead of a json

* break loading yaml and loading json apart

* remove experimental settings for bicep

* revert experimental flags

* update test

* expanding test case

* merge

* merge

* merge

* merge

* merged

* merged

* merged

* merged

* merged

* adding integration tests to LoadFunctionTests

* Update src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs



* adding yaml specific parsing error

* code review comments

* Update src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs



* comment out additional test

* add missing ARM_YAML_JSON which is the value of string(loadYamlFunction('test.yml'))

* adding IObjectParser and derived classes

* simplify

* update tests

* update tests

* update tests

* minor fixes

* fix up interface

* use common method for both types of loading

* use common method for both types of loading

* use common method for both types of loading

* use common method for both types of loading

* use common method for both types of loading

* use common method for both types of loading

* final refactors

* merged

* merged

* merged

* restore packages.lock.json

* restore csproj

* added sharpyaml

* refactorings

* restore deps

---------

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
